### PR TITLE
Migrate player activity from JSON files to database

### DIFF
--- a/Commands/activity.py
+++ b/Commands/activity.py
@@ -12,7 +12,7 @@ from discord.commands import slash_command, Option
 from PIL import Image, ImageFont, ImageDraw
 
 from Helpers.classes import PlaceTemplate, Page, Guild
-from Helpers.database import DB
+from Helpers.database import DB, get_current_guild_data
 from Helpers.functions import date_diff, isInCurrDay, expand_image, addLine, generate_rank_badge
 from Helpers.variables import rank_map as RANK_STARS_MAP, discord_ranks, guilds, te
 
@@ -258,7 +258,7 @@ class Activity(commands.Cog):
         await ctx.interaction.response.defer()
 
         uuid_to_rank = _load_discord_ranks()
-        current = _load_json('current_activity.json', {})
+        current = get_current_guild_data()
         current_members = current.get('members', []) if isinstance(current, dict) else []
 
         taq_members = Guild('The Aquarium').all_members

--- a/Commands/contribution.py
+++ b/Commands/contribution.py
@@ -11,7 +11,7 @@ from discord.ext import pages
 from discord.commands import slash_command
 
 from Helpers.classes import PlaceTemplate, Page, Guild
-from Helpers.database import DB
+from Helpers.database import DB, get_current_guild_data
 from Helpers.functions import isInCurrDay, expand_image, addLine, generate_rank_badge, format_number
 from Helpers.variables import rank_map, te, guilds
 import json
@@ -53,12 +53,13 @@ class Contribution(commands.Cog):
                        dayss: discord.Option(int, name="days", min_value=1, max_value=30, default=7)):
         await message.defer()
         book = []
-        with open('current_activity.json', 'r') as f:
-            new_data = json.loads(f.read())
+        current_data = get_current_guild_data()
 
         # Handle both dict and list formats
-        if isinstance(new_data, dict):
-            new_data = new_data.get('members', [])
+        if isinstance(current_data, dict):
+            new_data = current_data.get('members', [])
+        else:
+            new_data = current_data
 
         taq = Guild('The Aquarium').all_members
         playerdata = []

--- a/Commands/suggest_promotion.py
+++ b/Commands/suggest_promotion.py
@@ -11,15 +11,14 @@ from discord import option, default_permissions, slash_command
 from discord.ext import commands
 from discord.ui import View, Modal, InputText
 
-from Helpers.database import DB
+from Helpers.database import DB, get_current_guild_data
 from Helpers.functions import getPlayerUUID
 from Helpers.variables import test, te, promotion_channel, guilds
 
 
 async def get_members(message: discord.AutocompleteContext):
-    with open('current_activity.json', 'r') as f:
-        members = json.load(f)
-        f.close()
+    current_data = get_current_guild_data()
+    members = current_data.get('members', []) if isinstance(current_data, dict) else current_data
 
     member_list = []
     for member in members:
@@ -73,9 +72,8 @@ class SuggestPromotion(commands.Cog):
         taq_member = False
         username, UUID = getPlayerUUID(member)
 
-        with open('current_activity.json', 'r') as f:
-            members = json.load(f)
-            f.close()
+        current_data = get_current_guild_data()
+        members = current_data.get('members', []) if isinstance(current_data, dict) else current_data
 
         for m in members:
             if m['uuid'] == UUID:

--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -9,6 +9,8 @@ import traceback
 from datetime import timezone, timedelta, time as dtime
 from collections import deque
 from discord.ext import tasks, commands
+from discord.commands import slash_command
+from discord import default_permissions
 
 # ensure prints flush immediately
 if hasattr(sys.stdout, "reconfigure"):
@@ -25,7 +27,8 @@ from Helpers.variables import (
     notg_emoji_id,
     tcc_emoji_id,
     tna_emoji_id,
-    nol_emoji_id
+    nol_emoji_id,
+    guilds
 )
 
 RAID_ANNOUNCE_CHANNEL_ID = raid_log_channel
@@ -473,84 +476,102 @@ class UpdateMemberData(commands.Cog):
         
         print(f"🟨 ENDING LOOP - {datetime.datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}",flush=True)
 
-    @tasks.loop(time=dtime(hour=0, minute=1, tzinfo=timezone.utc))
-    async def daily_activity_snapshot(self):
-        print("Starting daily activity snapshot", flush=True)
+    async def _run_snapshot(self, target_date=None):
+        """
+        Core snapshot logic. Fetches all guild members and writes to player_activity table.
+        Uses UPSERT (ON CONFLICT DO UPDATE) for deduplication - safe to run multiple times.
 
-        # --- Guard: ensure only one snapshot per UTC day (check database) ---
-        today_utc = datetime.datetime.now(timezone.utc).date()
-        try:
-            db_check = DB()
-            db_check.connect()
-            db_check.cursor.execute("""
-                SELECT snapshot_date FROM player_activity
-                WHERE snapshot_date = %s
-                LIMIT 1
-            """, (today_utc,))
-            existing = db_check.cursor.fetchone()
-            db_check.close()
-            if existing:
-                print("Daily snapshot already exists for today; skipping duplicate.", flush=True)
-                return
-        except Exception:
-            traceback.print_exc()
-            # If the check fails, proceed to write a fresh snapshot below.
+        Args:
+            target_date: The date to use for the snapshot. Defaults to today UTC.
 
-        # --- Build snapshot (unchanged) ---
-        db = DB(); db.connect()
+        Returns:
+            Tuple of (success: bool, members_written: int, total_members: int)
+        """
+        if target_date is None:
+            target_date = datetime.datetime.now(timezone.utc).date()
+
+        print(f"Running snapshot for date: {target_date}", flush=True)
+
+        db = DB()
+        db.connect()
         guild = Guild("The Aquarium")
         snap = {'time': int(time.time()), 'members': []}
+
+        total_members = len(guild.all_members)
 
         # 1: build contrib and rank maps from recent guild state
         contrib_map = {m['uuid']: m.get('contributed', 0) for m in guild.all_members}
         rank_map    = {m['uuid']: m.get('rank')       for m in guild.all_members}
 
-        # 2: snapshot each member currently in guild
-        for m in guild.all_members:
-            uuid = m['uuid']
-            username = m['name']
+        # 2: snapshot each member currently in guild (with retry logic for rate limits)
+        pending_members = list(guild.all_members)
+        max_retries = 3
+        retry_delay = 30  # seconds
 
-            async with self._semaphore:
-                pf = await asyncio.to_thread(getPlayerDatav3, uuid)
-            if not isinstance(pf, dict):
-                continue
+        for attempt in range(max_retries + 1):
+            failed_members = []
 
-            # shells
-            db.cursor.execute(
-                "SELECT COALESCE(s.shells, 0) "
-                "FROM discord_links dl "
-                "LEFT JOIN shells s ON dl.discord_id = s.user "
-                "WHERE dl.uuid = %s",
-                (uuid,)
-            )
-            row = db.cursor.fetchone()
-            sh = row[0] if row else 0
+            for m in pending_members:
+                uuid = m['uuid']
+                username = m['name']
 
-            # raids
-            db.cursor.execute(
-                "SELECT COALESCE(ur.uncollected_raids, 0) + COALESCE(ur.collected_raids, 0) "
-                "FROM discord_links dl "
-                "LEFT JOIN uncollected_raids ur ON dl.uuid = ur.uuid "
-                "WHERE dl.uuid = %s",
-                (uuid,)
-            )
-            row = db.cursor.fetchone()
-            rd = row[0] if row else 0
+                async with self._semaphore:
+                    pf = await asyncio.to_thread(getPlayerDatav3, uuid)
+                if not isinstance(pf, dict):
+                    failed_members.append(m)
+                    continue
 
-            snap['members'].append({
-                'name': username,
-                'uuid': uuid,
-                'rank': rank_map.get(uuid),
-                'playtime': pf.get('playtime'),
-                'contributed': contrib_map.get(uuid),
-                'wars': pf.get('globalData', {}).get('wars'),
-                'shells': sh,
-                'raids': rd
-            })
+                # shells
+                db.cursor.execute(
+                    "SELECT COALESCE(s.shells, 0) "
+                    "FROM discord_links dl "
+                    "LEFT JOIN shells s ON dl.discord_id = s.user "
+                    "WHERE dl.uuid = %s",
+                    (uuid,)
+                )
+                row = db.cursor.fetchone()
+                sh = row[0] if row else 0
 
-        # 3: write to player_activity database table (all fields)
+                # raids
+                db.cursor.execute(
+                    "SELECT COALESCE(ur.uncollected_raids, 0) + COALESCE(ur.collected_raids, 0) "
+                    "FROM discord_links dl "
+                    "LEFT JOIN uncollected_raids ur ON dl.uuid = ur.uuid "
+                    "WHERE dl.uuid = %s",
+                    (uuid,)
+                )
+                row = db.cursor.fetchone()
+                rd = row[0] if row else 0
+
+                snap['members'].append({
+                    'name': username,
+                    'uuid': uuid,
+                    'rank': rank_map.get(uuid),
+                    'playtime': pf.get('playtime'),
+                    'contributed': contrib_map.get(uuid),
+                    'wars': pf.get('globalData', {}).get('wars'),
+                    'shells': sh,
+                    'raids': rd
+                })
+
+            # If no failures or we've exhausted retries, break
+            if not failed_members or attempt >= max_retries:
+                if failed_members:
+                    failed_names = [m['name'] for m in failed_members]
+                    print(f"[Snapshot] Final failures after {max_retries} retries: {', '.join(failed_names)}", flush=True)
+                break
+
+            # Wait and retry failed members
+            failed_names = [m['name'] for m in failed_members]
+            print(f"[Snapshot] {len(failed_members)} failed fetches: {', '.join(failed_names)}", flush=True)
+            print(f"[Snapshot] Waiting {retry_delay}s before retry {attempt + 1}/{max_retries}...", flush=True)
+            await asyncio.sleep(retry_delay)
+            pending_members = failed_members
+
+        failed_fetches = len(failed_members) if failed_members else 0
+
+        # 3: write to player_activity database table (uses UPSERT for deduplication)
         try:
-            snapshot_date = today_utc
             db_rows_written = 0
             for member in snap['members']:
                 uuid = member.get('uuid')
@@ -559,7 +580,7 @@ class UpdateMemberData(commands.Cog):
                 wars = member.get('wars') or 0
                 raids = member.get('raids') or 0
                 shells = member.get('shells') or 0
-                if uuid and playtime is not None:
+                if uuid:
                     db.cursor.execute("""
                         INSERT INTO player_activity (uuid, playtime, contributed, wars, raids, shells, snapshot_date)
                         VALUES (%s, %s, %s, %s, %s, %s, %s)
@@ -570,16 +591,108 @@ class UpdateMemberData(commands.Cog):
                             wars = EXCLUDED.wars,
                             raids = EXCLUDED.raids,
                             shells = EXCLUDED.shells
-                    """, (uuid, playtime, contributed, wars, raids, shells, snapshot_date))
+                    """, (uuid, playtime, contributed, wars, raids, shells, target_date))
                     db_rows_written += 1
             db.connection.commit()
-            print(f"Daily activity snapshot written to DB ({db_rows_written} rows)", flush=True)
+            private_profiles = sum(1 for m in snap['members'] if m.get('playtime') is None)
+            print(f"Snapshot written to DB ({db_rows_written} rows, {failed_fetches} failed API, {private_profiles} private profiles)", flush=True)
+            db.close()
+            return (True, db_rows_written, total_members, failed_fetches, private_profiles)
         except Exception as e:
-            print(f"[daily_activity_snapshot] Failed to write to DB: {e}", flush=True)
+            print(f"[_run_snapshot] Failed to write to DB: {e}", flush=True)
             traceback.print_exc()
+            db.close()
+            return (False, 0, total_members, failed_fetches, 0)
 
-        db.close()
-        print("Daily activity snapshot complete", flush=True)
+    @tasks.loop(time=dtime(hour=0, minute=1, tzinfo=timezone.utc))
+    async def daily_activity_snapshot(self):
+        print("Starting daily activity snapshot", flush=True)
+
+        # --- Guard: ensure only one snapshot per UTC day (check database) ---
+        today_utc = datetime.datetime.now(timezone.utc).date()
+        try:
+            db_check = DB()
+            db_check.connect()
+            db_check.cursor.execute("""
+                SELECT COUNT(*) FROM player_activity
+                WHERE snapshot_date = %s
+            """, (today_utc,))
+            existing_count = db_check.cursor.fetchone()[0]
+            db_check.close()
+            if existing_count > 0:
+                print(f"Daily snapshot already exists for today ({existing_count} rows); skipping.", flush=True)
+                return
+        except Exception:
+            traceback.print_exc()
+            # If the check fails, proceed to write a fresh snapshot below.
+
+        success, written, total, failed_api, private = await self._run_snapshot(today_utc)
+        if success:
+            print(f"Daily activity snapshot complete ({written}/{total} members, {failed_api} failed API, {private} private)", flush=True)
+        else:
+            print("Daily activity snapshot failed", flush=True)
+
+    @slash_command(name="force_snapshot", description="Force retry the daily activity snapshot (admin only)", guild_ids=guilds)
+    @default_permissions(administrator=True)
+    async def force_snapshot(self, ctx: discord.ApplicationContext):
+        """
+        Manually trigger a snapshot retry. Uses UPSERT so it's safe to run multiple times -
+        existing entries for today will be updated, not duplicated.
+        """
+        await ctx.defer(ephemeral=True)
+
+        today_utc = datetime.datetime.now(timezone.utc).date()
+
+        # Check current state before running
+        try:
+            db_check = DB()
+            db_check.connect()
+            db_check.cursor.execute("""
+                SELECT COUNT(*) FROM player_activity
+                WHERE snapshot_date = %s
+            """, (today_utc,))
+            existing_count = db_check.cursor.fetchone()[0]
+            db_check.close()
+        except Exception:
+            existing_count = 0
+
+        await ctx.respond(
+            f"Starting forced snapshot for {today_utc}...\n"
+            f"Current entries for today: {existing_count}\n"
+            f"This may take a minute.",
+            ephemeral=True
+        )
+
+        success, written, total, failed_api, private = await self._run_snapshot(today_utc)
+
+        # Check new state after running
+        try:
+            db_check = DB()
+            db_check.connect()
+            db_check.cursor.execute("""
+                SELECT COUNT(*) FROM player_activity
+                WHERE snapshot_date = %s
+            """, (today_utc,))
+            new_count = db_check.cursor.fetchone()[0]
+            db_check.close()
+        except Exception:
+            new_count = written
+
+        if success:
+            await ctx.followup.send(
+                f"✅ Snapshot complete!\n"
+                f"• Members in guild: {total}\n"
+                f"• Successfully written: {written}\n"
+                f"• Failed API fetches: {failed_api}\n"
+                f"• Private profiles (null playtime): {private}\n"
+                f"• Total entries for {today_utc}: {new_count}",
+                ephemeral=True
+            )
+        else:
+            await ctx.followup.send(
+                f"❌ Snapshot failed. Check logs for details.",
+                ephemeral=True
+            )
     
     @update_member_data.before_loop
     async def before_update(self):

--- a/Tasks/vanity_roles.py
+++ b/Tasks/vanity_roles.py
@@ -10,27 +10,18 @@ from discord.ext import commands, tasks
 from discord.commands import slash_command
 from discord import default_permissions
 
-from Helpers.database import DB
+from Helpers.database import DB, get_current_guild_data
 from Helpers.variables import guilds, announcement_channel, faq_channel, VANITY_ROLE_NAMES
 
 START_DATE_UTC = date(2025, 8, 31)  # first run date (YYYY, M, D)
 
 WINDOW_DAYS = 14  # bi-weekly window
 
-CURRENT_PATH = "current_activity.json"
 
 @dataclass
 class WindowedStats:
     wars: int
     raids: int
-
-
-def _load_json(path: str, default):
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception:
-        return default
 
 
 def _get_current_value(cur_by_uuid: Dict[str, Dict[str, Any]], uuid: str, key: str) -> int:
@@ -101,10 +92,10 @@ def _get_player_earliest_baseline(db: DB, uuid: str, key: str) -> int:
 def compute_windowed_stats(window_days: int = WINDOW_DAYS) -> Dict[str, WindowedStats]:
     """
     Returns { uuid -> WindowedStats(wars=Δ, raids=Δ) } for the last `window_days`.
-    Uses current_activity.json (live) minus baseline from player_activity database table.
+    Uses current guild data (live) minus baseline from player_activity database table.
     """
-    # Load current live data from JSON (updated every 3 minutes)
-    current = _load_json(CURRENT_PATH, {})
+    # Load current live data from database (updated every 3 minutes)
+    current = get_current_guild_data()
     cur_members = current.get("members", []) if isinstance(current, dict) else []
     cur_by_uuid = {m["uuid"]: m for m in cur_members if isinstance(m, dict) and m.get("uuid")}
 


### PR DESCRIPTION
## Summary
- Migrate all player activity data from JSON files to PostgreSQL database
- Add `get_current_guild_data()` and `get_player_activity_baseline()` helper functions
- Update PlayerStats, leaderboard, activity, contribution, suggest_promotion commands to use database
- Remove `current_activity.json` and `player_activity.json` file writes
- Add `/force_snapshot` admin command to manually retry daily snapshots with retry logic

## Changes
- **Helpers/database.py**: Add helper functions for database access
- **Helpers/classes.py**: Update PlayerStats to use database
- **Commands/**: Update leaderboard, activity, contribution, suggest_promotion to use database
- **Tasks/vanity_roles.py**: Use database for current guild data
- **Tasks/update_member_data.py**: Remove JSON writes, add force_snapshot command with retry logic

## Data Sources (now database-only)
- **Live data**: `cache_entries` table (key `'guildData'`) - updated every 3 min
- **Historical snapshots**: `player_activity` table - updated daily at 00:01 UTC

## Test plan
- [x] Test bot connects and loads all extensions
- [x] Test `/force_snapshot` command works with retry logic
- [ ] Test `/profile` command works correctly
- [ ] Test `/leaderboard` commands work correctly
- [ ] Test `/contribution` command works correctly