### PR TITLE
Fix weekly/biweekly stats counting entire career for new/returning members

### DIFF
--- a/Commands/top_wars.py
+++ b/Commands/top_wars.py
@@ -84,11 +84,14 @@ def get_wars_in_range(start_date: datetime.date, end_date: datetime.date) -> Dic
         # Calculate deltas for current guild members only
         result = {}
         for uuid in current_uuids:
-            start_val = start_wars.get(uuid, 0)
-            end_val = end_wars.get(uuid, 0)
-
+            # Exclude players without start date data (mid-week joins, returning members)
+            if uuid not in start_wars:
+                continue
             if uuid not in end_wars:
                 continue
+
+            start_val = start_wars[uuid]
+            end_val = end_wars[uuid]
 
             delta = end_val - start_val
             if delta < 0:


### PR DESCRIPTION
## Summary
- Fixes bug where players without baseline data on the start date had their entire career stats counted as weekly/biweekly earnings
- Mid-week joins and returning members no longer appear with inflated stats on leaderboards
- Affects `/top_wars`, `/contribution`, and biweekly vanity role assignment

## Changes
- **top_wars.py**: Skip players missing from `start_wars` dict instead of defaulting to 0
- **contribution.py**: Return `None` for missing baselines and skip those players
- **vanity_roles.py**: Return `None` on missing data, remove fallback to earliest snapshot, skip players without baseline data

## Test plan
- [ ] Run `/top_wars` with a date range that includes mid-week joins - verify they don't appear
- [ ] Run `/contribution` - verify new/returning members are excluded
- [ ] Run `/vanityroles preview` - verify new/returning members don't get inflated role assignments