### PR TITLE
Enhance recruiter tracking system

### DIFF
--- a/Commands/wave_promote.py
+++ b/Commands/wave_promote.py
@@ -174,7 +174,7 @@ class WavePromote(commands.Cog):
 
                 # Google Sheets tracking (non-fatal)
                 try:
-                    from Helpers.sheets import update_promo
+                    from Helpers.sheets import update_promo, find_by_ign, update_paid
                     from Helpers.functions import getUsernameFromUUID
                     name_result = await asyncio.to_thread(getUsernameFromUUID, uuid)
                     if name_result:
@@ -182,6 +182,10 @@ class WavePromote(commands.Cog):
                             await asyncio.to_thread(update_promo, name_result, "manateePromo")
                         if new_index >= ranks_list.index("Piranha"):
                             await asyncio.to_thread(update_promo, name_result, "piranhaPromo")
+                            sheet_row = await asyncio.to_thread(find_by_ign, name_result)
+                            if sheet_row.get("success") and sheet_row.get("data"):
+                                if sheet_row["data"].get("paid") == "NYP":
+                                    await asyncio.to_thread(update_paid, name_result, "N")
                 except Exception as e:
                     err_ch = self.client.get_channel(error_channel)
                     if err_ch:

--- a/Events/on_member_update.py
+++ b/Events/on_member_update.py
@@ -48,7 +48,7 @@ class OnMemberUpdate(commands.Cog):
             return
 
         try:
-            from Helpers.sheets import find_by_ign, update_promo
+            from Helpers.sheets import find_by_ign, update_promo, update_paid
 
             # Look up UUID from discord_links (blocking, run in thread)
             uuid = await asyncio.to_thread(_db_lookup_uuid, after.id)
@@ -75,6 +75,11 @@ class OnMemberUpdate(commands.Cog):
                 if not sheet_row["data"].get("manateePromo", False):
                     await asyncio.to_thread(update_promo, ign, "manateePromo")
             await asyncio.to_thread(update_promo, ign, promo)
+
+            # Update paid to "N" on Piranha promo if still "NYP"
+            if promo == "piranhaPromo":
+                if sheet_row["data"].get("paid") == "NYP":
+                    await asyncio.to_thread(update_paid, ign, "N")
 
         except Exception as e:
             err_ch = self.client.get_channel(error_channel)

--- a/Helpers/sheets.py
+++ b/Helpers/sheets.py
@@ -21,14 +21,25 @@ def _post(payload: dict) -> dict:
         return {"success": False, "error": str(e)}
 
 
-def add_row(ticket: str, ign: str, recruiter: str, type_: str = "Member") -> dict:
-    return _post({
+def add_row(
+    ticket: str,
+    ign: str,
+    recruiter: str,
+    type_: str = "Member",
+    paid: str = "NYP",
+    recruiter_format: dict | None = None,
+) -> dict:
+    payload = {
         "action": "addRow",
         "ticket": ticket,
         "type": type_,
         "ign": ign,
         "recruiter": recruiter,
-    })
+        "paid": paid,
+    }
+    if recruiter_format is not None:
+        payload["recruiterFormat"] = recruiter_format
+    return _post(payload)
 
 
 def update_type(ign: str, type_: str) -> dict:

--- a/UserCommands/rank_promote.py
+++ b/UserCommands/rank_promote.py
@@ -149,7 +149,7 @@ class RankPromote(commands.Cog):
 
         # Update recruiter tracking sheet (non-fatal)
         try:
-            from Helpers.sheets import update_promo
+            from Helpers.sheets import update_promo, find_by_ign, update_paid
             from Helpers.functions import getUsernameFromUUID
             import asyncio
             name_result = await asyncio.to_thread(getUsernameFromUUID, uuid)
@@ -160,6 +160,10 @@ class RankPromote(commands.Cog):
                     await asyncio.to_thread(update_promo, ign, "manateePromo")
                 if new_index >= ranks_keys.index("Piranha"):
                     await asyncio.to_thread(update_promo, ign, "piranhaPromo")
+                    sheet_row = await asyncio.to_thread(find_by_ign, ign)
+                    if sheet_row.get("success") and sheet_row.get("data"):
+                        if sheet_row["data"].get("paid") == "NYP":
+                            await asyncio.to_thread(update_paid, ign, "N")
         except Exception as e:
             err_ch = self.client.get_channel(error_channel)
             if err_ch:

--- a/apps_script/recruiter_tracker.gs
+++ b/apps_script/recruiter_tracker.gs
@@ -53,7 +53,7 @@ function getSheet() {
 
 /**
  * Add a new row to the spreadsheet.
- * payload: { ticket, type, ign, recruiter }
+ * payload: { ticket, type, ign, recruiter, paid?, recruiterFormat?: {bold, fontColor} }
  */
 function addRow(payload) {
   var sheet = getSheet();
@@ -61,6 +61,7 @@ function addRow(payload) {
   var type = payload.type || "Member";
   var ign = payload.ign || "";
   var recruiter = payload.recruiter || "";
+  var paid = payload.paid || "NYP";
 
   // Insert at row 2 (top, below header) with empty promo columns
   sheet.insertRowAfter(1);
@@ -69,7 +70,26 @@ function addRow(payload) {
   newRow.clearDataValidations();
   // Copy formatting from existing data row (row 3) so alternating colors stay correct
   sheet.getRange(3, 1, 1, lastCol).copyTo(newRow, SpreadsheetApp.CopyPasteType.PASTE_FORMAT, false);
-  sheet.getRange(2, 1, 1, 7).setValues([[ticket, type, ign, recruiter, "", "", "NYP"]]);
+  sheet.getRange(2, 1, 1, 7).setValues([[ticket, type, ign, recruiter, "", "", paid]]);
+
+  // Apply optional formatting to recruiter cell (column D)
+  var fmt = payload.recruiterFormat;
+  if (fmt) {
+    var recruiterCell = sheet.getRange(2, 4);
+    if (fmt.bold) {
+      recruiterCell.setFontWeight("bold");
+    }
+    if (fmt.fontColor) {
+      recruiterCell.setFontColor(fmt.fontColor);
+    }
+  }
+
+  // Sort data rows by ticket number (column A) descending so highest is at top
+  var lastRow = sheet.getLastRow();
+  if (lastRow > 1) {
+    sheet.getRange(2, 1, lastRow - 1, lastCol).sort({ column: 1, ascending: false });
+  }
+
   return { success: true };
 }
 


### PR DESCRIPTION
## Summary
- **Old member detection**: AI-based, DB UUID check, and Discord role check — auto-sets recruiter to "old member" with bold dark yellow formatting and paid=NP
- **Recruiter fuzzy matching**: Local exact/substring match with OpenAI AI fallback for ambiguous or misspelled names
- **Chief/owner coloring**: Recruiter cell colored magenta (owner/Narwhal chief) or purple (Dolphin chief) on Google Sheets, paid=NP
- **Paid status logic**: NP for no/unmatched recruiter, NYP→N on Piranha promotion (rank promote, wave promote, and fallback role detection)
- **Guild leave UUID fallback**: Handles IGN changes by looking up stored IGN from discord_links when sheet lookup by API name fails
- **Spreadsheet auto-sort**: Rows sorted by ticket number (column A) descending after each insert
- **Prompt migration**: Moved OpenAI application parsing prompt from stored platform prompt to inline code

## Test plan
- [ ] Accept application from ex-member (Ex-Member role) — sheet shows "old member" (bold, dark yellow), paid=NP
- [ ] Accept application with misspelled recruiter name — fuzzy matches to correct guild member
- [ ] Accept application where recruiter is a chief — recruiter name colored appropriately
- [ ] Accept application with no recruiter mentioned — recruiter blank, paid=NP
- [ ] Promote member to Piranha — paid column changes from NYP to N
- [ ] Member leaves guild — Type changes to Left, paid to LG if applicable
- [ ] Member with changed IGN leaves — UUID fallback finds correct sheet row