### PR TITLE
Feat: shell to aspect exchange

### DIFF
--- a/Commands/generate.py
+++ b/Commands/generate.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 import hashlib
 import hmac
 import json
@@ -14,6 +15,7 @@ from discord.ui import View, button
 from discord import Permissions
 
 from Helpers.database import DB
+from Helpers.logger import log, ERROR
 from Helpers.variables import (
     HOME_GUILD_IDS,
     WEBSITE_URL,
@@ -247,6 +249,218 @@ class ConvertView(View):
         )
 
 
+# ---- Shell convert view ----
+
+class ShellConvertView(View):
+    def __init__(self):
+        super().__init__(timeout=None)
+
+    @button(label="Shells -> Aspects", style=discord.ButtonStyle.green, custom_id="shells_to_aspects")
+    async def shells_to_aspects(self, _: discord.ui.Button, interaction: discord.Interaction):
+        # Linked account check
+        db = DB(); db.connect()
+        db.cursor.execute(
+            "SELECT uuid FROM discord_links WHERE discord_id = %s",
+            (interaction.user.id,)
+        )
+        link_row = db.cursor.fetchone()
+        if not link_row:
+            db.close()
+            return await interaction.response.send_message(
+                "You don't have a linked game account. Please use `/link` first.",
+                ephemeral=True
+            )
+        uuid = str(link_row[0])
+
+        # No pending uncollected aspects allowed
+        db.cursor.execute(
+            "SELECT uncollected_aspects FROM uncollected_raids WHERE uuid = %s",
+            (uuid,)
+        )
+        raids_row = db.cursor.fetchone()
+        if raids_row and raids_row[0] > 0:
+            db.close()
+            return await interaction.response.send_message(
+                f"You already have **{raids_row[0]}** uncollected aspect(s) waiting. "
+                "Collect them before converting more shells.",
+                ephemeral=True
+            )
+
+        # Shell balance check (need at least 4 for one aspect)
+        db.cursor.execute(
+            'SELECT balance, last_aspect_convert_at FROM shells WHERE "user" = %s',
+            (str(interaction.user.id),)
+        )
+        shells_row = db.cursor.fetchone()
+        balance = shells_row[0] if shells_row else 0
+        if balance < 6:
+            db.close()
+            return await interaction.response.send_message(
+                f"You need at least **6** shells to convert (you have **{balance}**).",
+                ephemeral=True
+            )
+
+        # Cooldown check (3 days between conversions)
+        last_convert_at = shells_row[1] if shells_row else None
+        if last_convert_at is not None:
+            ready_at = last_convert_at + datetime.timedelta(days=3)
+            if datetime.datetime.now(datetime.timezone.utc) < ready_at:
+                db.close()
+                ts = int(ready_at.timestamp())
+                return await interaction.response.send_message(
+                    f"You are on cooldown. You can convert again <t:{ts}:R>.",
+                    ephemeral=True
+                )
+        db.close()
+
+        # All guards passed -- open the amount modal (cap at 40 per conversion)
+        max_aspects = min(balance // 6, 40)
+        modal = ShellsToAspectsModal(
+            discord_id=interaction.user.id,
+            uuid=uuid,
+            balance=balance,
+            max_aspects=max_aspects,
+        )
+        await interaction.response.send_modal(modal)
+
+
+# ---- Shells to aspects modal ----
+
+class ShellsToAspectsModal(discord.ui.Modal):
+    def __init__(self, discord_id: int, uuid: str, balance: int, max_aspects: int):
+        super().__init__(title="Shells -> Aspects")
+        self.discord_id  = discord_id
+        self.uuid        = uuid
+        self.balance     = balance
+        self.max_aspects = max_aspects
+
+        self.amount_input = discord.ui.InputText(
+            label=f"How many aspects? (max {max_aspects}, 6 shells each)",
+            placeholder=f"Enter a number from 1 to {max_aspects}",
+            style=discord.InputTextStyle.short,
+            max_length=4,
+            required=True,
+        )
+        self.add_item(self.amount_input)
+
+    async def callback(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+
+        # Parse and validate input
+        raw = self.amount_input.value.strip()
+        if not raw.isdigit() or int(raw) < 1:
+            return await interaction.followup.send(
+                "Enter a valid number of aspects (at least 1).",
+                ephemeral=True
+            )
+        amount = int(raw)
+        if amount > self.max_aspects:
+            return await interaction.followup.send(
+                f"You can convert at most **{self.max_aspects}** aspect(s) "
+                f"with your current balance ({self.balance} shells).",
+                ephemeral=True
+            )
+
+        cost = amount * 6
+        remaining = self.balance - cost
+
+        # Preview embed with conversion breakdown -- user must confirm
+        embed = discord.Embed(title="Confirm Conversion", color=discord.Color.blurple())
+        embed.add_field(name="Current Shells", value=f"{self.balance} {SHELL_EMOJI}", inline=False)
+        embed.add_field(name="Cost", value=f"{cost} {SHELL_EMOJI} ({amount} {ASPECT_EMOJI})", inline=False)
+        embed.add_field(name="Remaining Shells", value=f"{remaining} {SHELL_EMOJI}", inline=False)
+        embed.set_footer(text="Click Confirm to complete the conversion.")
+
+        view = ShellConfirmView(
+            discord_id=self.discord_id,
+            uuid=self.uuid,
+            balance=self.balance,
+            amount=amount,
+            cost=cost,
+        )
+        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+
+
+# ---- Shell confirm view ----
+
+class ShellConfirmView(View):
+    def __init__(self, discord_id: int, uuid: str, balance: int, amount: int, cost: int):
+        super().__init__(timeout=180)
+        self.discord_id = discord_id
+        self.uuid       = uuid
+        self.balance    = balance
+        self.amount     = amount
+        self.cost       = cost
+
+    @button(label="Confirm", style=discord.ButtonStyle.green, custom_id="shell_confirm")
+    async def confirm(self, _: discord.ui.Button, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+
+        # Single atomic transaction: deduct shells and credit aspects
+        db = DB(); db.connect()
+        try:
+            db.cursor.execute("""
+                UPDATE shells
+                   SET balance                = balance - %s,
+                       last_aspect_convert_at = NOW()
+                 WHERE "user" = %s AND balance >= %s
+            """, (self.cost, str(self.discord_id), self.cost))
+
+            if db.cursor.rowcount == 0:
+                db.connection.rollback()
+                db.close()
+                await interaction.edit_original_response(embed=None, view=None,
+                    content="You no longer have enough shells for this conversion.")
+                return
+
+            # UPSERT handles both existing and new uncollected_raids rows
+            db.cursor.execute("""
+                INSERT INTO uncollected_raids (uuid, uncollected_aspects)
+                     VALUES (%s, %s)
+                ON CONFLICT (uuid) DO UPDATE
+                        SET uncollected_aspects =
+                              uncollected_raids.uncollected_aspects + EXCLUDED.uncollected_aspects
+            """, (self.uuid, self.amount))
+
+            # Audit log entry matching 
+            db.cursor.execute(
+                "INSERT INTO audit_log (log_type, actor_name, actor_id, action) VALUES (%s, %s, %s, %s)",
+                ('shell', interaction.user.name, interaction.user.id,
+                 f"converted {self.cost} shells into {self.amount} aspect(s) (self-service).")
+            )
+
+            db.connection.commit()
+        except Exception as e:
+            log(ERROR, f"shell convert transaction failed for {interaction.user} ({self.discord_id}): {e}", context="generate")
+            db.connection.rollback()
+            db.close()
+            await interaction.edit_original_response(embed=None, view=None,
+                content="An internal error occurred. No shells were deducted. Please try again.")
+            return
+        db.close()
+
+        await interaction.edit_original_response(
+            embed=None, view=None,
+            content=(
+                f"Converted **{self.cost}** {SHELL_EMOJI} into **{self.amount}** {ASPECT_EMOJI}!\n"
+                f"Your aspects have been added to the collection queue."
+            )
+        )
+
+    @button(label="Cancel", style=discord.ButtonStyle.secondary, custom_id="shell_confirm_cancel")
+    async def cancel(self, _: discord.ui.Button, interaction: discord.Interaction):
+        await interaction.response.edit_message(embed=None, view=None, content="Conversion cancelled.")
+
+    async def on_timeout(self):
+        # Disable all buttons when the 3-minute window expires
+        for child in self.children:
+            child.disabled = True
+        try:
+            await self.message.edit(view=self, content="This conversion request has expired.", embed=None)
+        except Exception:
+            pass  # message may already be gone
+
+
 # ---- Cog ----
 
 class Generate(commands.Cog):
@@ -350,10 +564,44 @@ class Generate(commands.Cog):
 
         await ctx.followup.send("✅ Posted the raid-collecting message.", ephemeral=True)
 
+    @generate.command(name="shell_convert", description="ADMIN: Post the Shells -> Aspects conversion panel")
+    async def shell_convert(self, ctx: discord.ApplicationContext):
+        await ctx.defer(ephemeral=True)
+
+        view = ShellConvertView()
+        self.client.add_view(view)
+
+        # Embed styled to match the raid collecting panel
+        embed = discord.Embed(color=discord.Color.blurple())
+        embed.description = dedent(f"""
+            {SHELL_EMOJI} **Convert Shells into Aspects**
+
+            Spend your shells to earn aspects directly. Shell conversion lets you use your shell balance to receive aspects without needing to complete additional raids.
+
+            Conversion rate: **6 {SHELL_EMOJI} = 1 {ASPECT_EMOJI}**
+
+            **Requirements**
+            - No uncollected aspects already waiting
+            - At least **6** shells in balance
+            - At most **40** aspects per conversion
+            - 3-day cooldown between conversions
+
+            **How to Convert**
+            1. Click the **Shells -> Aspects** button.
+            2. Enter how many aspects you want to claim.
+            3. Confirm your conversion in the preview.
+
+            _Your aspects will be added to the collection queue automatically. Note: depending on current demand, it may take up to a week or two for your aspects to be delivered._
+            """)
+
+        await ctx.channel.send(embed=embed, view=view)
+        await ctx.followup.send("Posted the shell conversion panel.", ephemeral=True)
+
     @commands.Cog.listener()
     async def on_ready(self):
         self.client.add_view(ApplicationButtonView())
         self.client.add_view(ClaimView())
+        self.client.add_view(ShellConvertView())
 
 
 def setup(client):

--- a/schema.sql
+++ b/schema.sql
@@ -51,10 +51,11 @@ CREATE TABLE IF NOT EXISTS profile_customization (
 );
 
 CREATE TABLE IF NOT EXISTS shells (
-  "user"  BIGINT      PRIMARY KEY,
-  shells  INT         NOT NULL DEFAULT 0,
-  balance INT         NOT NULL DEFAULT 0,
-  ign     VARCHAR(64)
+  "user"                 BIGINT      PRIMARY KEY,
+  shells                 INT         NOT NULL DEFAULT 0,
+  balance                INT         NOT NULL DEFAULT 0,
+  ign                    VARCHAR(64),
+  last_aspect_convert_at TIMESTAMPTZ
 );
 
 -- =============================================================================


### PR DESCRIPTION
added shell to aspects panel in similar fashion to raid collecting
includes:
- check for minimum shells owned
- input field for how many aspects
- check for cooldown (3 days, saved in DB in shell panel)
- confirmation view with total shells pre transaction, cost + aspect amount, and shells after transaction
- timeout after 180sec
- generate via /generate shell_convert in desired channel