### PR TITLE
feat: add avatar caching and reduce redundant API calls

### DIFF
--- a/Commands/profile.py
+++ b/Commands/profile.py
@@ -16,7 +16,7 @@ from Helpers.functions import pretty_date, generate_rank_badge, generate_banner,
 from Helpers.logger import log, ERROR
 from Helpers.variables import discord_ranks, minecraft_colors, minecraft_banner_colors
 from Helpers.rate_limiter import external_rate_limit
-from Helpers.storage import get_background
+from Helpers.storage import get_background, get_cached_avatar, save_cached_avatar
 
 
 class Profile(commands.Cog):
@@ -92,10 +92,19 @@ class Profile(commands.Cog):
 
         # Player Avatar
         try:
-            headers = {'User-Agent': os.getenv("visage_UA")}
-            url = f"https://visage.surgeplay.com/bust/500/{player.UUID}"
-            response = requests.get(url, headers=headers, timeout=6)
-            skin = Image.open(BytesIO(response.content))
+            cached = get_cached_avatar(player.UUID)
+            if cached:
+                skin = Image.open(BytesIO(cached))
+            else:
+                headers = {'User-Agent': os.getenv("visage_UA")}
+                url = f"https://visage.surgeplay.com/bust/500/{player.UUID}"
+                response = requests.get(url, headers=headers, timeout=6)
+                response.raise_for_status()
+                try:
+                    save_cached_avatar(player.UUID, response.content)
+                except Exception:
+                    pass
+                skin = Image.open(BytesIO(response.content))
         except Exception as e:
             log(ERROR, f"{e}", context="profile")
             skin = Image.open('images/profile/x-steve500.png')
@@ -111,7 +120,7 @@ class Profile(commands.Cog):
         if player.guild:
             # Get Guild Color
             try:
-                guild_banner = getData(player.guild)['banner']
+                guild_banner = player.guild_data['banner'] if player.guild_data else getData(player.guild)['banner']
                 if guild_banner['base'] in ['BLACK', 'GRAY', 'BROWN']:
                     for layer in guild_banner['layers']:
                         if layer['colour'] not in ['BLACK', 'GRAY', 'BROWN']:
@@ -149,7 +158,7 @@ class Profile(commands.Cog):
             card.paste(guild_rank_badge, (108, 667), guild_rank_badge)
 
             # Guild Banner
-            banner = generate_banner(player.guild, 15, "2")
+            banner = generate_banner(player.guild, 15, "2", guild_data=player.guild_data)
             banner.thumbnail((157, 157))
             card.paste(banner, (41, 562))
 

--- a/Commands/raids.py
+++ b/Commands/raids.py
@@ -105,8 +105,10 @@ class Raids(commands.Cog):
             await ctx.followup.send(embed=embed, ephemeral=True)
             return
 
-        # 2) Fetch raw player data for raid stats ----------------------------------
-        player = await self._fetch_player(name)
+        # 2) Reuse the raw player payload loaded by PlayerStats for raid stats ------
+        player = getattr(player_stats, "player_data", None)
+        if not isinstance(player, dict):
+            player = await self._fetch_player(name)
         if player is None:
             embed = discord.Embed(
                 title=':no_entry: Player not found',
@@ -336,9 +338,10 @@ class Raids(commands.Cog):
             return
 
         gname = guild_info.get('name', '')
+        guild_data = getattr(player_stats, 'guild_data', None)
         # Derive a readable color from banner
         try:
-            banner = getData(gname)['banner']
+            banner = guild_data['banner'] if guild_data else getData(gname)['banner']
             base = banner.get('base')
             if base in ['BLACK', 'GRAY', 'BROWN']:
                 colour = next(layer['colour'] for layer in banner['layers'] if layer['colour'] not in ['BLACK', 'GRAY', 'BROWN'])
@@ -383,7 +386,7 @@ class Raids(commands.Cog):
 
         # Minecraft-style banner icon
         try:
-            bn = generate_banner(gname, 15, "2")
+            bn = generate_banner(gname, 15, "2", guild_data=guild_data)
             bn.thumbnail((157, 157))
             bn = bn.convert('RGBA')
         except Exception:

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -8,8 +8,12 @@ from dateutil import parser
 import discord
 from discord.ui import InputText, Modal
 
-from Helpers.database import DB, get_current_guild_data, get_player_activity_baseline
-from Helpers.functions import getPlayerUUID, getPlayerDatav3, urlify, determine_starting_rank
+from Helpers.database import (
+    DB,
+    get_current_guild_data_with_db,
+    get_player_activity_baseline_with_db,
+)
+from Helpers.functions import getPlayerUUID, getPlayerDatav3, getPlayerProfileDatav3, urlify, determine_starting_rank
 from discord.ext.pages import Page as _Page
 
 from Helpers.variables import wynn_ranks, WELCOME_CHANNEL_ID, discord_ranks
@@ -28,6 +32,7 @@ class Guild:
         resp.raise_for_status()
         guild_data = resp.json()
 
+        self.data = guild_data
         self.name = guild_data['name']
         self.prefix = guild_data['prefix']
         self.level = guild_data['level']
@@ -65,17 +70,24 @@ class PlayerStats:
         db = DB()
         db.connect()
         try:
-            player_data = getPlayerUUID(name)
-            if not player_data:
-                self.error = True
-                return
-            else:
+            pdata = getPlayerProfileDatav3(name)
+            if pdata:
                 self.error = False
-            self.UUID = player_data[1]
-            self.username = player_data[0]
-
-            # player data
-            pdata = getPlayerDatav3(self.UUID)
+                self.UUID = pdata['uuid']
+                self.username = pdata['username']
+            else:
+                player_data = getPlayerUUID(name)
+                if not player_data:
+                    self.error = True
+                    return
+                self.error = False
+                self.UUID = player_data[1]
+                self.username = player_data[0]
+                pdata = getPlayerDatav3(self.UUID)
+                if not pdata:
+                    self.error = True
+                    return
+            self.player_data = pdata
 
             # Track which fields are private/null
             test_last_joined = pdata.get('lastJoin')
@@ -138,17 +150,23 @@ class PlayerStats:
             self.total_level_is_private = raw_total_level is None
 
             # guild data
-            self.taq = self.isInTAq(self.UUID)
+            taq_gdata = Guild('The Aquarium')
+            taq_member_by_uuid = {member['uuid']: member for member in taq_gdata.all_members}
+            guild_stats = taq_member_by_uuid.get(self.UUID)
+
+            self.taq = guild_stats is not None
             self.guild = 'The Aquarium' if self.taq else pdata.get('guild')
             if self.guild is not None:
                 self.guild = 'The Aquarium' if self.taq else pdata.get('guild', {}).get('name')
-                gdata = Guild(self.guild)
-                for guildee in gdata.all_members:
-                    if guildee['uuid'] == self.UUID:
-                        guild_stats = guildee
-                        break
-                    else:
-                        pass
+                gdata = taq_gdata if self.taq else Guild(self.guild)
+                self.guild_data = gdata.data
+                if guild_stats is None:
+                    for guildee in gdata.all_members:
+                        if guildee['uuid'] == self.UUID:
+                            guild_stats = guildee
+                            break
+                    if guild_stats is None:
+                        guild_stats = {}
                 self.guild_rank = guild_stats.get('rank') if self.taq else pdata.get('guild', {}).get('rank')
 
                 # Guild contributed - track if null or missing
@@ -162,6 +180,7 @@ class PlayerStats:
                 self.in_guild_for = delta
             else:
                 self.guild = None
+                self.guild_data = None
                 self.guild_rank = None
                 self.guild_contributed = None
                 self.guild_contributed_is_private = False
@@ -206,7 +225,10 @@ class PlayerStats:
             # timed stats (using database for both current and baseline data)
             if self.taq:
                 # 1) Load NOW from database cache so profiles match the leaderboard exactly
-                cur = get_current_guild_data()
+                try:
+                    cur = get_current_guild_data_with_db(db)
+                except Exception:
+                    cur = {}
                 cur_map = {m['uuid']: m for m in cur.get('members', [])}
                 now_entry = cur_map.get(self.UUID)
 
@@ -235,15 +257,11 @@ class PlayerStats:
 
                 # 2) Bound the requested days for display (keep your UX constraints)
                 # Get number of available snapshots from database
-                db_temp = DB()
-                db_temp.connect()
                 try:
-                    db_temp.cursor.execute("SELECT COUNT(DISTINCT snapshot_date) FROM player_activity")
-                    num_snaps = db_temp.cursor.fetchone()[0] or 0
+                    db.cursor.execute("SELECT COUNT(DISTINCT snapshot_date) FROM player_activity")
+                    num_snaps = db.cursor.fetchone()[0] or 0
                 except Exception:
                     num_snaps = 0
-                finally:
-                    db_temp.close()
 
                 # Keep your original limits
                 if days > num_snaps:
@@ -257,10 +275,10 @@ class PlayerStats:
                 if self.in_guild_for.days >= 1:
                     # Get baseline values from database, filtered to current membership period
                     jd = self.guild_joined.date() if self.guild_joined else None
-                    base_pt, warn_pt = get_player_activity_baseline(self.UUID, 'playtime', days, joined_date=jd)
-                    base_wars, warn_wars = get_player_activity_baseline(self.UUID, 'wars', days, joined_date=jd)
-                    base_xp, warn_xp = get_player_activity_baseline(self.UUID, 'contributed', days, joined_date=jd)
-                    base_raids, warn_raids = get_player_activity_baseline(self.UUID, 'raids', days, joined_date=jd)
+                    base_pt, warn_pt = get_player_activity_baseline_with_db(db, self.UUID, 'playtime', days, joined_date=jd)
+                    base_wars, warn_wars = get_player_activity_baseline_with_db(db, self.UUID, 'wars', days, joined_date=jd)
+                    base_xp, warn_xp = get_player_activity_baseline_with_db(db, self.UUID, 'contributed', days, joined_date=jd)
+                    base_raids, warn_raids = get_player_activity_baseline_with_db(db, self.UUID, 'raids', days, joined_date=jd)
                     warn_flag = warn_pt or warn_wars or warn_xp or warn_raids
 
                     # 3) Compute inclusive deltas (clamped >= 0)

--- a/Helpers/database.py
+++ b/Helpers/database.py
@@ -75,18 +75,23 @@ def get_current_guild_data() -> dict:
     db = DB()
     db.connect()
     try:
-        db.cursor.execute(
-            "SELECT data FROM cache_entries WHERE cache_key = 'guildData'"
-        )
-        row = db.cursor.fetchone()
-        if row and row[0]:
-            return row[0] if isinstance(row[0], dict) else json.loads(row[0])
-        return {}
+        return get_current_guild_data_with_db(db)
     except Exception as e:
         log(ERROR, f"Error: {e}", context="database")
         return {}
     finally:
         db.close()
+
+
+def get_current_guild_data_with_db(db: DB) -> dict:
+    """Load current guild member data using an existing DB connection."""
+    db.cursor.execute(
+        "SELECT data FROM cache_entries WHERE cache_key = 'guildData'"
+    )
+    row = db.cursor.fetchone()
+    if row and row[0]:
+        return row[0] if isinstance(row[0], dict) else json.loads(row[0])
+    return {}
 
 
 def get_player_activity_baseline(uuid: str, key: str, days: int, joined_date: datetime.date = None) -> tuple:

--- a/Helpers/functions.py
+++ b/Helpers/functions.py
@@ -5,6 +5,7 @@ import os
 import json
 import re
 from io import BytesIO
+from urllib.parse import quote
 from uuid import UUID
 
 import certifi
@@ -51,6 +52,20 @@ def getPlayerDatav3(uuid, token=None):
         resp = requests.get(url, timeout=20, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         resp.raise_for_status()
         return resp.json()
+    except requests.RequestException:
+        return False
+
+
+def getPlayerProfileDatav3(player, token=None):
+    """Fetch a full player profile by username or UUID, preserving old fallbacks for ambiguous names."""
+    url = f'https://api.wynncraft.com/v3/player/{quote(str(player))}?fullResult'
+    try:
+        resp = requests.get(url, timeout=20, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        if resp.status_code == 300:
+            return False
+        resp.raise_for_status()
+        payload = resp.json()
+        return payload if payload.get('uuid') else False
     except requests.RequestException:
         return False
 
@@ -392,14 +407,16 @@ def round_corners(img, radius=25):
     return img
 
 
-def generate_banner(guild, scale, style=''):
-    url = f"https://api.wynncraft.com/v3/guild/{urlify(guild)}"
-    try:
-        resp = requests.get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
-        resp.raise_for_status()
-        data = resp.json()
-    except requests.RequestException:
-        return Image.open(f'images/banner{style}/base.png')
+def generate_banner(guild, scale, style='', guild_data=None):
+    data = guild_data
+    if data is None:
+        url = f"https://api.wynncraft.com/v3/guild/{urlify(guild)}"
+        try:
+            resp = requests.get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException:
+            return Image.open(f'images/banner{style}/base.png')
 
     if data['banner']:
         banner = data['banner']


### PR DESCRIPTION
- Cache player avatars locally via get_cached_avatar/save_cached_avatar to avoid repeated requests to the Visage API
- Reuse already-fetched player and guild data from PlayerStats instead of re-fetching through separate API calls
- Pass guild_data through to generate_banner to prevent duplicate getData() lookups
- Handle both 'colour' and 'color' keys in guild banner layers for compatibility with varying API responses


/profile was taking a minute straight couldnt let this stay..