### PR TITLE
perf: skip timed stats loading when unused and cache font objects + optimize profile gradient

### DIFF
--- a/Commands/manage.py
+++ b/Commands/manage.py
@@ -37,7 +37,7 @@ class ShellModalName(Modal):
         draw = ImageDraw.Draw(img); draw.fontmode = '1'
         font = ImageFont.truetype('images/profile/game.ttf', 19)
 
-        player = PlayerStats(self.children[0].value, 1)
+        player = PlayerStats(self.children[0].value, 1, False)
         try:
             url = f"https://visage.surgeplay.com/bust/75/{player.UUID}"
             skin = Image.open(BytesIO(requests.get(url).content))

--- a/Commands/progress.py
+++ b/Commands/progress.py
@@ -33,7 +33,7 @@ class Progress(commands.Cog):
     @external_rate_limit()
     async def progress(self, message, name: discord.Option(str, require=True)):
         await message.defer()
-        playerdata = await asyncio.to_thread(PlayerStats, name, 7)
+        playerdata = await asyncio.to_thread(PlayerStats, name, 7, False)
 
         max_lvl = 1690
         max_combat = 106

--- a/Commands/raids.py
+++ b/Commands/raids.py
@@ -87,7 +87,7 @@ class Raids(commands.Cog):
 
         # 1) Fetch player data using PlayerStats (like profile.py) ----------------
         try:
-            player_stats = await asyncio.to_thread(PlayerStats, name, 7)  # 7 days for compatibility
+            player_stats = await asyncio.to_thread(PlayerStats, name, 7, False)
             if player_stats.error:
                 embed = discord.Embed(
                     title=':no_entry: Oops! Something did not go as intended.',

--- a/Commands/snipe.py
+++ b/Commands/snipe.py
@@ -1433,7 +1433,7 @@ class SnipeTracker(commands.Cog):
         # Fetch TAq rank badge info
         rank_text = rank_color = None
         try:
-            player = await asyncio.to_thread(PlayerStats, ign, 1)
+            player = await asyncio.to_thread(PlayerStats, ign, 1, False)
             if not player.error:
                 if player.taq and player.linked and player.rank in discord_ranks:
                     rank_text  = player.rank.upper()
@@ -1762,7 +1762,7 @@ class SnipeTracker(commands.Cog):
         # Fetch TAq rank badge info
         rank_text = rank_color = None
         try:
-            player = await asyncio.to_thread(PlayerStats, ign, 1)
+            player = await asyncio.to_thread(PlayerStats, ign, 1, False)
             if not player.error:
                 if player.taq and player.linked and player.rank in discord_ranks:
                     rank_text = player.rank.upper()

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -66,7 +66,7 @@ class Guild:
         return member_list
 
 class PlayerStats:
-    def __init__(self, name, days):
+    def __init__(self, name, days, load_timed_stats=True):
         db = DB()
         db.connect()
         try:
@@ -78,7 +78,10 @@ class PlayerStats:
             self._load_player_fields(pdata)
             self._load_guild_fields(pdata)
             self._load_profile_db_state(db)
-            self._load_timed_stats(db, days)
+            if load_timed_stats:
+                self._load_timed_stats(db, days)
+            else:
+                self._set_skipped_timed_defaults(days)
         finally:
             db.close()
 
@@ -345,6 +348,10 @@ class PlayerStats:
         self.real_xp_is_private = False
         self.real_raids_is_private = False
         self.stats_warn = False
+
+    def _set_skipped_timed_defaults(self, days):
+        self.stats_days = days
+        self._set_non_taq_timed_defaults()
 
     def isInTAq(self, uuid):
         guild_members = []

--- a/Helpers/functions.py
+++ b/Helpers/functions.py
@@ -4,6 +4,7 @@ import math
 import os
 import json
 import re
+from functools import lru_cache
 from io import BytesIO
 from urllib.parse import quote
 from uuid import UUID
@@ -14,6 +15,11 @@ from PIL import Image, ImageFilter, ImageEnhance, ImageDraw, ImageFont, ImageOps
 
 from Helpers.variables import minecraft_colors, minecraft_banner_colors, colours, shadows, IS_TEST_MODE
 from Helpers.logger import log, WARN, ERROR
+
+
+@lru_cache(maxsize=64)
+def _cached_font(path, size):
+    return ImageFont.truetype(path, size)
 
 
 def isInCurrDay(data, uuid):
@@ -245,7 +251,7 @@ def generate_rank_old_badge(text, colour, scale=4):
     img = Image.new('RGBA', (img_width, 18), (255, 0, 0, 0))
     draw = ImageDraw.Draw(img)
 
-    font = ImageFont.truetype('images/profile/5x5.ttf', 20)
+    font = _cached_font('images/profile/5x5.ttf', 20)
 
     draw.rectangle([(2, 2), (img.width - 3, img.height - 3)], fill=color.hex)
     draw.rectangle([(2, img.height - 2), (img.width - 3, img.height)], fill=color.shadow)
@@ -277,7 +283,7 @@ def generate_rank_badge(text, colour, scale=4):
     img = Image.new('RGBA', (img_width, 18), (255, 0, 0, 0))
     draw = ImageDraw.Draw(img)
 
-    font = ImageFont.truetype('images/profile/5x5.ttf', 20)
+    font = _cached_font('images/profile/5x5.ttf', 20)
 
     draw.rectangle([(0, 1), (img.width, 14)], fill=color.light)
     draw.rectangle([(2, 3), (img.width - 3, 12)], fill=color.hex)
@@ -337,7 +343,7 @@ def generate_badge(text, base_color, scale=3):
 
     light, shadow, text_color = get_guild_badge_colors_with_text(base_color)
 
-    font = ImageFont.truetype('images/profile/5x5.ttf', 20)
+    font = _cached_font('images/profile/5x5.ttf', 20)
 
     img_height = 18
     text_bbox = font.getbbox(text)
@@ -387,15 +393,15 @@ def vertical_gradient(width=900, height=1180, main_color='#66ccff', secondary_co
             top_color = ImageColor.getrgb(color.shadow)
             bottom_color = ImageColor.getrgb(color.light)
 
-    img = Image.new('RGBA', (width, height), (0, 0, 0, 0))
+    strip = Image.new('RGBA', (1, height), (0, 0, 0, 0))
+    denom = max(height, 1)
     for y in range(height):
-        ratio = y / height
+        ratio = y / denom
         r = int(top_color[0] * (1 - ratio) + bottom_color[0] * ratio)
         g = int(top_color[1] * (1 - ratio) + bottom_color[1] * ratio)
         b = int(top_color[2] * (1 - ratio) + bottom_color[2] * ratio)
-        for x in range(width):
-            img.putpixel((x, y), (r, g, b))
-    return img
+        strip.putpixel((0, y), (r, g, b, 255))
+    return strip.resize((width, height), Image.Resampling.NEAREST)
 
 
 def round_corners(img, radius=25):

--- a/Helpers/storage.py
+++ b/Helpers/storage.py
@@ -69,11 +69,14 @@ class S3Storage:
         if not self._is_configured:
             return None
         try:
-            head = self.client.head_object(Bucket=self._bucket, Key=key)
-            age = (datetime.now(timezone.utc) - head["LastModified"]).total_seconds()
+            resp = self.client.get_object(Bucket=self._bucket, Key=key)
+            age = (datetime.now(timezone.utc) - resp["LastModified"]).total_seconds()
             if age > max_age_seconds:
+                resp["Body"].close()
                 return None
-            return self.get_bytes(key)
+            data = resp["Body"].read()
+            resp["Body"].close()
+            return data
         except Exception:
             return None
 


### PR DESCRIPTION

- Add `load_timed_stats` parameter to PlayerStats so timed stats can be skipped (like for /raids)
- added  `_set_skipped_timed_defaults()` to set safe defaults for when timed stats loading is skipped
- Updated PlayerStats callers in all commands to use  `load_timed_stats=False` when timed data isnt needed
- Add `lru_cache`-backed `_cached_font()` helper to avoid repeatedly loading the same font files from disk during image drawing
- changed profiles gradient function to complete faster