### PR TITLE
Phase 0: command latency instrumentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,5 +48,8 @@ TEST_S3_BUCKET_NAME=
 # Error Notifications (your Discord user ID — who gets pinged on bot errors)
 ERROR_PING_USER_ID=
 
+# Latency telemetry (Phase 0 instrumentation) — set to 0 to disable stdout timing records
+LATENCY_TELEMETRY=1
+
 # Legacy Shell Exchange Webhook
 LEGACY_WEBHOOK_URL=

--- a/Commands/profile.py
+++ b/Commands/profile.py
@@ -5,7 +5,6 @@ from io import BytesIO
 import asyncio
 
 import discord
-import requests
 from PIL import Image, ImageDraw, ImageFont
 from discord.ext import commands
 from discord.commands import slash_command

--- a/Commands/profile.py
+++ b/Commands/profile.py
@@ -12,7 +12,7 @@ from discord.commands import slash_command
 import json
 
 from Helpers.classes import PlayerStats
-from Helpers.functions import pretty_date, generate_rank_badge, generate_banner, getData, format_number, addLine, vertical_gradient, round_corners, generate_badge
+from Helpers.functions import pretty_date, generate_rank_badge, generate_banner, getData, format_number, addLine, vertical_gradient, round_corners, generate_badge, timed_get
 from Helpers.logger import log, ERROR
 from Helpers.variables import discord_ranks, minecraft_colors, minecraft_banner_colors
 from Helpers.rate_limiter import external_rate_limit
@@ -98,7 +98,7 @@ class Profile(commands.Cog):
             else:
                 headers = {'User-Agent': os.getenv("visage_UA")}
                 url = f"https://visage.surgeplay.com/bust/500/{player.UUID}"
-                response = requests.get(url, headers=headers, timeout=6)
+                response = timed_get(url, headers=headers, timeout=6)
                 response.raise_for_status()
                 try:
                     save_cached_avatar(player.UUID, response.content)

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timezone
 import json
-import requests
 import os
 
 from PIL import Image, ImageOps

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -13,7 +13,7 @@ from Helpers.database import (
     get_current_guild_data_and_snapshot_count_with_db,
     get_player_activity_baselines_with_db,
 )
-from Helpers.functions import getPlayerUUID, getPlayerDatav3, getPlayerProfileDatav3, urlify, determine_starting_rank
+from Helpers.functions import getPlayerUUID, getPlayerDatav3, getPlayerProfileDatav3, urlify, determine_starting_rank, timed_get
 from discord.ext.pages import Page as _Page
 
 from Helpers.variables import wynn_ranks, WELCOME_CHANNEL_ID, discord_ranks
@@ -28,7 +28,7 @@ class Guild:
         else:
             url = f'https://api.wynncraft.com/v3/guild/{urlify(guild)}'
 
-        resp = requests.get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        resp = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         resp.raise_for_status()
         guild_data = resp.json()
 

--- a/Helpers/database.py
+++ b/Helpers/database.py
@@ -7,7 +7,59 @@ import time
 import psycopg2
 from psycopg2 import OperationalError
 
+from Helpers import telemetry
 from Helpers.logger import log, ERROR
+
+
+class _TimedCursor:
+    """Times execute/executemany into db.query; delegates everything else.
+
+    Delegation is via __getattr__ rather than an explicit method list so that
+    fetchone/fetchall/close and anything else keep working untouched.
+    """
+
+    def __init__(self, cursor):
+        self.__dict__["_cursor"] = cursor
+
+    def execute(self, *args, **kwargs):
+        with telemetry.track("db.query"):
+            return self.__dict__["_cursor"].execute(*args, **kwargs)
+
+    def executemany(self, *args, **kwargs):
+        with telemetry.track("db.query"):
+            return self.__dict__["_cursor"].executemany(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self.__dict__["_cursor"], name)
+
+    def __setattr__(self, name, value):
+        setattr(self.__dict__["_cursor"], name, value)
+
+    def __iter__(self):
+        return iter(self.__dict__["_cursor"])
+
+    def __enter__(self):
+        return self.__dict__["_cursor"].__enter__()
+
+    def __exit__(self, *exc):
+        return self.__dict__["_cursor"].__exit__(*exc)
+
+
+class _TimedConnection:
+    """Times commit into db.commit; delegates everything else."""
+
+    def __init__(self, connection):
+        self.__dict__["_connection"] = connection
+
+    def commit(self, *args, **kwargs):
+        with telemetry.track("db.commit"):
+            return self.__dict__["_connection"].commit(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self.__dict__["_connection"], name)
+
+    def __setattr__(self, name, value):
+        setattr(self.__dict__["_connection"], name, value)
 
 
 class DB:
@@ -18,33 +70,37 @@ class DB:
     def connect(self):
         try:
             if os.getenv("TEST_MODE").lower() == "true":
-                self.connection = psycopg2.connect(
-                    user=os.getenv("TEST_DB_LOGIN"),
-                    password=os.getenv("TEST_DB_PASS"),
-                    host=os.getenv("TEST_DB_HOST"),
-                    port=int(os.getenv("TEST_DB_PORT")),
-                    database=os.getenv("TEST_DB_DATABASE", "postgres"),
-                    sslmode=os.getenv("TEST_DB_SSLMODE"),
-                    keepalives=1,
-                    keepalives_idle=30,
-                    keepalives_interval=10,
-                    keepalives_count=5
-                )
-                self.cursor = self.connection.cursor()
+                with telemetry.track("db.connect"):
+                    raw_connection = psycopg2.connect(
+                        user=os.getenv("TEST_DB_LOGIN"),
+                        password=os.getenv("TEST_DB_PASS"),
+                        host=os.getenv("TEST_DB_HOST"),
+                        port=int(os.getenv("TEST_DB_PORT")),
+                        database=os.getenv("TEST_DB_DATABASE", "postgres"),
+                        sslmode=os.getenv("TEST_DB_SSLMODE"),
+                        keepalives=1,
+                        keepalives_idle=30,
+                        keepalives_interval=10,
+                        keepalives_count=5
+                    )
+                self.connection = _TimedConnection(raw_connection)
+                self.cursor = _TimedCursor(raw_connection.cursor())
             elif os.getenv("TEST_MODE").lower() == "false":
-                self.connection = psycopg2.connect(
-                    user=os.getenv("DB_LOGIN"),
-                    password=os.getenv("DB_PASS"),
-                    host=os.getenv("DB_HOST"),
-                    port=int(os.getenv("DB_PORT")),
-                    database=os.getenv("DB_DATABASE", "postgres"),
-                    sslmode=os.getenv("DB_SSLMODE"),
-                    keepalives=1,
-                    keepalives_idle=30,
-                    keepalives_interval=10,
-                    keepalives_count=5
-                )
-                self.cursor = self.connection.cursor()
+                with telemetry.track("db.connect"):
+                    raw_connection = psycopg2.connect(
+                        user=os.getenv("DB_LOGIN"),
+                        password=os.getenv("DB_PASS"),
+                        host=os.getenv("DB_HOST"),
+                        port=int(os.getenv("DB_PORT")),
+                        database=os.getenv("DB_DATABASE", "postgres"),
+                        sslmode=os.getenv("DB_SSLMODE"),
+                        keepalives=1,
+                        keepalives_idle=30,
+                        keepalives_interval=10,
+                        keepalives_count=5
+                    )
+                self.connection = _TimedConnection(raw_connection)
+                self.cursor = _TimedCursor(raw_connection.cursor())
             else:
                 log(ERROR, "Problem logging into db", context="database")
                 exit(-1)

--- a/Helpers/functions.py
+++ b/Helpers/functions.py
@@ -432,17 +432,20 @@ def round_corners(img, radius=25):
 
 
 def generate_banner(guild, scale, style='', guild_data=None):
-    with telemetry.track("render"):
-        data = guild_data
-        if data is None:
-            url = f"https://api.wynncraft.com/v3/guild/{urlify(guild)}"
-            try:
-                resp = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
-                resp.raise_for_status()
-                data = resp.json()
-            except requests.RequestException:
-                return Image.open(f'images/banner{style}/base.png')
+    # The optional guild fetch stays OUTSIDE the render bucket: it is already
+    # timed by timed_get's http.<host> bucket, and counting it under "render"
+    # too would double-count network latency for callers that omit guild_data.
+    data = guild_data
+    if data is None:
+        url = f"https://api.wynncraft.com/v3/guild/{urlify(guild)}"
+        try:
+            resp = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException:
+            return Image.open(f'images/banner{style}/base.png')
 
+    with telemetry.track("render"):
         if data['banner']:
             banner = data['banner']
 

--- a/Helpers/functions.py
+++ b/Helpers/functions.py
@@ -6,7 +6,7 @@ import json
 import re
 from functools import lru_cache
 from io import BytesIO
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from uuid import UUID
 
 import certifi
@@ -15,11 +15,26 @@ from PIL import Image, ImageFilter, ImageEnhance, ImageDraw, ImageFont, ImageOps
 
 from Helpers.variables import minecraft_colors, minecraft_banner_colors, colours, shadows, IS_TEST_MODE
 from Helpers.logger import log, WARN, ERROR
+from Helpers import telemetry
 
 
 @lru_cache(maxsize=64)
 def _cached_font(path, size):
     return ImageFont.truetype(path, size)
+
+
+def timed_get(url, **kwargs):
+    """requests.get with per-host timing.
+
+    Deliberately does NOT reuse a Session. Phase 0 must not change behaviour, and
+    session reuse is a Phase 1 fix whose benefit is measured against these numbers.
+    """
+    try:
+        host = urlparse(url).hostname or "unknown"
+    except Exception:
+        host = "unknown"
+    with telemetry.track(f"http.{host}"):
+        return requests.get(url, **kwargs)
 
 
 def isInCurrDay(data, uuid):
@@ -45,7 +60,7 @@ def getPlayerData(name, token=None):
         name = 'aa7402cc-bf1c-4aed-838b-fd8897d38836'
     url = f'https://api.wynncraft.com/v2/player/{name}/stats'
     try:
-        resp = requests.get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        resp = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         resp.raise_for_status()
         return resp.json()
     except requests.RequestException:
@@ -55,7 +70,7 @@ def getPlayerData(name, token=None):
 def getPlayerDatav3(uuid, token=None):
     url = f'https://api.wynncraft.com/v3/player/{uuid}?fullResult'
     try:
-        resp = requests.get(url, timeout=20, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        resp = timed_get(url, timeout=20, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         resp.raise_for_status()
         return resp.json()
     except requests.RequestException:
@@ -66,7 +81,7 @@ def getPlayerProfileDatav3(player, token=None):
     """Fetch a full player profile by username or UUID, preserving old fallbacks for ambiguous names."""
     url = f'https://api.wynncraft.com/v3/player/{quote(str(player))}?fullResult'
     try:
-        resp = requests.get(url, timeout=20, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        resp = timed_get(url, timeout=20, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         if resp.status_code == 300:
             return False
         resp.raise_for_status()
@@ -79,7 +94,7 @@ def getPlayerProfileDatav3(player, token=None):
 def getData(guild, token=None):
     url = f"https://api.wynncraft.com/v3/guild/{urlify(guild)}"
     try:
-        resp = requests.get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        resp = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         resp.raise_for_status()
         return resp.json()
     except requests.RequestException:
@@ -158,7 +173,7 @@ def getGuildMembers(guild, token=None):
       f'?action=guildStats&command={urlify(guild)}'
     )
     try:
-        resp = requests.get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        resp = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         resp.raise_for_status()
         return resp.json().get('members', [])
     except requests.RequestException:
@@ -179,13 +194,13 @@ def dropShadow(image):
 
 def getPlayerUUID(player, token=None):
     try:
-        req = requests.get(f"https://api.mojang.com/users/profiles/minecraft/{player}")
+        req = timed_get(f"https://api.mojang.com/users/profiles/minecraft/{player}")
         username = req.json()['name']
         player_uuid = UUID(req.json()['id'])
         return [username, str(player_uuid)]
     except:
         try:
-            req = requests.get(f"https://api.wynncraft.com/v3/player/{player}", headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"}, timeout=10)
+            req = timed_get(f"https://api.wynncraft.com/v3/player/{player}", headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"}, timeout=10)
             username = req.json()['username']
             player_uuid = UUID(req.json()['uuid'])
             return [username, str(player_uuid)]
@@ -210,7 +225,7 @@ def determine_starting_rank(member):
 
 def getNameFromUUID(uuid):
     try:
-        req = requests.get(f"https://sessionserver.mojang.com/session/minecraft/profile/{uuid}")
+        req = timed_get(f"https://sessionserver.mojang.com/session/minecraft/profile/{uuid}")
         username = req.json()['name']
         player_uuid = UUID(req.json()['id'])
         return [username, str(player_uuid)]
@@ -418,7 +433,7 @@ def generate_banner(guild, scale, style='', guild_data=None):
     if data is None:
         url = f"https://api.wynncraft.com/v3/guild/{urlify(guild)}"
         try:
-            resp = requests.get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
+            resp = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
             resp.raise_for_status()
             data = resp.json()
         except requests.RequestException:
@@ -582,7 +597,7 @@ def generate_applicant_info(pdata):
     try:
         headers = {'User-Agent': os.getenv("visage_UA")}
         url = f"https://visage.surgeplay.com/bust/190/{pdata.UUID}"
-        response = requests.get(url, headers=headers)
+        response = timed_get(url, headers=headers)
         skin = Image.open(BytesIO(response.content))
     except:
         skin = Image.open('images/profile/X-Steve.webp')
@@ -701,7 +716,7 @@ def getOnlinePlayers(token=None):
     # Preferred v3 endpoint (30 seconds TTL)
     v3_url = "https://api.wynncraft.com/v3/player"
     try:
-        resp = requests.get(v3_url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        resp = timed_get(v3_url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         if resp.status_code == 200:
             data = resp.json()
             if 'players' in data and isinstance(data['players'], dict):
@@ -712,7 +727,7 @@ def getOnlinePlayers(token=None):
     # Fallback to legacy endpoint (using a different timeout for the fallback)
     legacy_url = "https://api.wynncraft.com/public_api.php?action=onlinePlayers"
     try:
-        resp = requests.get(legacy_url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        resp = timed_get(legacy_url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         if resp.status_code == 200:
             data = resp.json()
             # Legacy format returns a list of servers, each with a list of players
@@ -748,7 +763,7 @@ def getOnlinePlayersUUID(token=None):
     uuid_url = "https://api.wynncraft.com/v3/player?identifier=uuid"
 
     try:
-        resp = requests.get(uuid_url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
+        resp = timed_get(uuid_url, timeout=10, headers={"Authorization": f"Bearer {os.getenv(token or 'WYNN_TOKEN')}"})
         if resp.status_code == 200:
             data = resp.json()
             players = data.get("players", {})
@@ -798,7 +813,7 @@ def getUsernameFromUUID(uuid: str) -> str | None:
 
     url = f"https://sessionserver.mojang.com/session/minecraft/profile/{uuid_nodash}"
     try:
-        resp = requests.get(url, timeout=8, verify=certifi.where())
+        resp = timed_get(url, timeout=8, verify=certifi.where())
         if resp.status_code == 200:
             data = resp.json()
             name = data.get("name")

--- a/Helpers/functions.py
+++ b/Helpers/functions.py
@@ -288,37 +288,38 @@ def generate_rank_old_badge(text, colour, scale=4):
 
 
 def generate_rank_badge(text, colour, scale=4):
-    if colour[0] != '#':
-        colour = '#' + colour
-    match = re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', colour)
-    if not match:
-        return False
-    color = Color(colour)
-    img_width = len(text) * 12 + 12
-    img = Image.new('RGBA', (img_width, 18), (255, 0, 0, 0))
-    draw = ImageDraw.Draw(img)
+    with telemetry.track("render"):
+        if colour[0] != '#':
+            colour = '#' + colour
+        match = re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', colour)
+        if not match:
+            return False
+        color = Color(colour)
+        img_width = len(text) * 12 + 12
+        img = Image.new('RGBA', (img_width, 18), (255, 0, 0, 0))
+        draw = ImageDraw.Draw(img)
 
-    font = _cached_font('images/profile/5x5.ttf', 20)
+        font = _cached_font('images/profile/5x5.ttf', 20)
 
-    draw.rectangle([(0, 1), (img.width, 14)], fill=color.light)
-    draw.rectangle([(2, 3), (img.width - 3, 12)], fill=color.hex)
-    draw.rectangle([(0, 11), (3, 14)], fill=color.shadow)
-    draw.rectangle([(img.width - 4, 11), (img.width, 14)], fill=color.shadow)
-    draw.rectangle([(2, 15), (img.width - 3, 16)], fill=color.shadow)
-    draw.rectangle([(2, 11), (3, 12)], fill=color.light)
-    draw.rectangle([(img.width - 4, 11), (img.width - 3, 12)], fill=color.light)
-    draw.text((img.width / 2 + 2, img.height / 2 - 3), text, font=font, anchor="mm", fill=color.shadow)
-    draw.text((img.width / 2, img.height / 2 - 3), text, font=font, anchor="mm")
+        draw.rectangle([(0, 1), (img.width, 14)], fill=color.light)
+        draw.rectangle([(2, 3), (img.width - 3, 12)], fill=color.hex)
+        draw.rectangle([(0, 11), (3, 14)], fill=color.shadow)
+        draw.rectangle([(img.width - 4, 11), (img.width, 14)], fill=color.shadow)
+        draw.rectangle([(2, 15), (img.width - 3, 16)], fill=color.shadow)
+        draw.rectangle([(2, 11), (3, 12)], fill=color.light)
+        draw.rectangle([(img.width - 4, 11), (img.width - 3, 12)], fill=color.light)
+        draw.text((img.width / 2 + 2, img.height / 2 - 3), text, font=font, anchor="mm", fill=color.shadow)
+        draw.text((img.width / 2, img.height / 2 - 3), text, font=font, anchor="mm")
 
-    # textshade = Image.new("RGBA", (img.width, 4), (255, 0, 0, 0))
-    # shadedraw = ImageDraw.Draw(textshade)
-    # shadedraw.text((img.width / 2, textshade.height), text, font=font, anchor="mb", fill=color.shade)
+        # textshade = Image.new("RGBA", (img.width, 4), (255, 0, 0, 0))
+        # shadedraw = ImageDraw.Draw(textshade)
+        # shadedraw.text((img.width / 2, textshade.height), text, font=font, anchor="mb", fill=color.shade)
 
-    # img.paste(textshade, (0, 10), textshade)
+        # img.paste(textshade, (0, 10), textshade)
 
-    img = img.resize((img.width * scale, img.height * scale), resample=Image.Resampling.NEAREST)
+        img = img.resize((img.width * scale, img.height * scale), resample=Image.Resampling.NEAREST)
 
-    return img
+        return img
 
 
 def get_guild_badge_colors_with_text(colour):
@@ -386,125 +387,129 @@ def generate_badge(text, base_color, scale=3):
 
 
 def vertical_gradient(width=900, height=1180, main_color='#66ccff', secondary_color=False, reverse=False):
-    if main_color[0] != '#':
-        main_color = '#' + main_color
-    match = re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', main_color)
-    if not match:
-        return False
-    if secondary_color is not False:
-        if secondary_color[0] != '#':
-            secondary_color = '#' + secondary_color
-        match = re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', secondary_color)
+    with telemetry.track("render"):
+        if main_color[0] != '#':
+            main_color = '#' + main_color
+        match = re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', main_color)
         if not match:
             return False
-        top_color = ImageColor.getrgb(main_color)
-        bottom_color = ImageColor.getrgb(secondary_color)
-    else:
-        color = Color(main_color)
-        if not reverse:
-            top_color = ImageColor.getrgb(color.light)
-            bottom_color = ImageColor.getrgb(color.shadow)
+        if secondary_color is not False:
+            if secondary_color[0] != '#':
+                secondary_color = '#' + secondary_color
+            match = re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', secondary_color)
+            if not match:
+                return False
+            top_color = ImageColor.getrgb(main_color)
+            bottom_color = ImageColor.getrgb(secondary_color)
         else:
-            top_color = ImageColor.getrgb(color.shadow)
-            bottom_color = ImageColor.getrgb(color.light)
+            color = Color(main_color)
+            if not reverse:
+                top_color = ImageColor.getrgb(color.light)
+                bottom_color = ImageColor.getrgb(color.shadow)
+            else:
+                top_color = ImageColor.getrgb(color.shadow)
+                bottom_color = ImageColor.getrgb(color.light)
 
-    strip = Image.new('RGBA', (1, height), (0, 0, 0, 0))
-    denom = max(height, 1)
-    for y in range(height):
-        ratio = y / denom
-        r = int(top_color[0] * (1 - ratio) + bottom_color[0] * ratio)
-        g = int(top_color[1] * (1 - ratio) + bottom_color[1] * ratio)
-        b = int(top_color[2] * (1 - ratio) + bottom_color[2] * ratio)
-        strip.putpixel((0, y), (r, g, b, 255))
-    return strip.resize((width, height), Image.Resampling.NEAREST)
+        strip = Image.new('RGBA', (1, height), (0, 0, 0, 0))
+        denom = max(height, 1)
+        for y in range(height):
+            ratio = y / denom
+            r = int(top_color[0] * (1 - ratio) + bottom_color[0] * ratio)
+            g = int(top_color[1] * (1 - ratio) + bottom_color[1] * ratio)
+            b = int(top_color[2] * (1 - ratio) + bottom_color[2] * ratio)
+            strip.putpixel((0, y), (r, g, b, 255))
+        return strip.resize((width, height), Image.Resampling.NEAREST)
 
 
 def round_corners(img, radius=25):
-    img = img.convert("RGBA")
-    rounded_mask = Image.new("L", img.size, 0)
-    draw = ImageDraw.Draw(rounded_mask)
-    draw.rounded_rectangle([(0, 0), img.size], radius=radius, fill=255)
-    img.putalpha(rounded_mask)
-    return img
+    with telemetry.track("render"):
+        img = img.convert("RGBA")
+        rounded_mask = Image.new("L", img.size, 0)
+        draw = ImageDraw.Draw(rounded_mask)
+        draw.rounded_rectangle([(0, 0), img.size], radius=radius, fill=255)
+        img.putalpha(rounded_mask)
+        return img
 
 
 def generate_banner(guild, scale, style='', guild_data=None):
-    data = guild_data
-    if data is None:
-        url = f"https://api.wynncraft.com/v3/guild/{urlify(guild)}"
-        try:
-            resp = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
-            resp.raise_for_status()
-            data = resp.json()
-        except requests.RequestException:
-            return Image.open(f'images/banner{style}/base.png')
+    with telemetry.track("render"):
+        data = guild_data
+        if data is None:
+            url = f"https://api.wynncraft.com/v3/guild/{urlify(guild)}"
+            try:
+                resp = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
+                resp.raise_for_status()
+                data = resp.json()
+            except requests.RequestException:
+                return Image.open(f'images/banner{style}/base.png')
 
-    if data['banner']:
-        banner = data['banner']
+        if data['banner']:
+            banner = data['banner']
 
-        bg = Image.open(f'images/banner{style}/base.png')
+            bg = Image.open(f'images/banner{style}/base.png')
 
-        w, h = bg.size
+            w, h = bg.size
 
-        crop_x1 = w / 64
-        crop_y1 = h / 64
-        crop_x2 = (w / 2) - (11 * crop_x1)
-        crop_y2 = h - (24 * crop_y1)
+            crop_x1 = w / 64
+            crop_y1 = h / 64
+            crop_x2 = (w / 2) - (11 * crop_x1)
+            crop_y2 = h - (24 * crop_y1)
 
-        bg = bg.crop((crop_x1, crop_y1, crop_x2, crop_y2))
+            bg = bg.crop((crop_x1, crop_y1, crop_x2, crop_y2))
 
-        bg = bg.convert("L")
+            bg = bg.convert("L")
 
-        bg = ImageOps.colorize(bg, "black", minecraft_banner_colors[banner['base']])
+            bg = ImageOps.colorize(bg, "black", minecraft_banner_colors[banner['base']])
 
-        for layer in banner['layers']:
-            if w == 64:
-                mask = Image.open(f'images/banner/{layer["pattern"].lower()}.png')
-                mask = mask.crop((crop_x1, crop_y1, crop_x2, crop_y2))
-            pattern = Image.open(f'images/banner{style}/{layer["pattern"].lower()}.png')
-            pattern = pattern.crop((crop_x1, crop_y1, crop_x2, crop_y2))
-            pattern = pattern.convert("RGBA")
+            for layer in banner['layers']:
+                if w == 64:
+                    mask = Image.open(f'images/banner/{layer["pattern"].lower()}.png')
+                    mask = mask.crop((crop_x1, crop_y1, crop_x2, crop_y2))
+                pattern = Image.open(f'images/banner{style}/{layer["pattern"].lower()}.png')
+                pattern = pattern.crop((crop_x1, crop_y1, crop_x2, crop_y2))
+                pattern = pattern.convert("RGBA")
 
-            pattern2 = pattern.convert("L")
+                pattern2 = pattern.convert("L")
 
-            pattern2 = ImageOps.colorize(pattern2, "black", minecraft_banner_colors[layer['colour']])
+                pattern2 = ImageOps.colorize(pattern2, "black", minecraft_banner_colors[layer['colour']])
 
-            bg.paste(pattern2, (0, 0), mask)
+                bg.paste(pattern2, (0, 0), mask)
 
-    else:
-        bg = Image.open(f'images/banner{style}/base.png')
+        else:
+            bg = Image.open(f'images/banner{style}/base.png')
 
-        w, h = bg.size
+            w, h = bg.size
 
-        crop_x1 = w / 64
-        crop_y1 = h / 64
-        crop_x2 = (w / 2) - (11 * crop_x1)
-        crop_y2 = h - (24 * crop_y1)
+            crop_x1 = w / 64
+            crop_y1 = h / 64
+            crop_x2 = (w / 2) - (11 * crop_x1)
+            crop_y2 = h - (24 * crop_y1)
 
-        bg = bg.crop((crop_x1, crop_y1, crop_x2, crop_y2))
+            bg = bg.crop((crop_x1, crop_y1, crop_x2, crop_y2))
 
-    bg = bg.resize((bg.width * scale, bg.height * scale), Image.NEAREST)
+        bg = bg.resize((bg.width * scale, bg.height * scale), Image.NEAREST)
 
-    return bg
+        return bg
 
 
 def addLine(text, draw, font, x, y, drop_x=2, drop_y=2, anchor=None):
-    if text[0] != '&':
-        text = f'&f{text}'
+    with telemetry.track("render"):
+        if text[0] != '&':
+            text = f'&f{text}'
 
-    strlist = re.findall('&[^&]+', text)
+        strlist = re.findall('&[^&]+', text)
 
-    for word in strlist:
-        if word[1] == '#':
-            _, _, w, h = draw.textbbox((0, 0), word[8::], font=font)
-            draw.text((x + drop_x, y + drop_y), word[8::], font=font, fill=darken_color(word[1:8], 0.72), anchor=anchor)
-            draw.text((x, y), word[8::], font=font, fill=word[1:8], anchor=anchor)
-        else:
-            _, _, w, h = draw.textbbox((0, 0), word[2::], font=font)
-            draw.text((x + drop_x, y + drop_y), word[2::], font=font, fill=shadows[word[1]], anchor=anchor)
-            draw.text((x, y), word[2::], font=font, fill=colours[word[1]], anchor=anchor)
-        x += w
-    return x
+        for word in strlist:
+            if word[1] == '#':
+                _, _, w, h = draw.textbbox((0, 0), word[8::], font=font)
+                draw.text((x + drop_x, y + drop_y), word[8::], font=font, fill=darken_color(word[1:8], 0.72), anchor=anchor)
+                draw.text((x, y), word[8::], font=font, fill=word[1:8], anchor=anchor)
+            else:
+                _, _, w, h = draw.textbbox((0, 0), word[2::], font=font)
+                draw.text((x + drop_x, y + drop_y), word[2::], font=font, fill=shadows[word[1]], anchor=anchor)
+                draw.text((x, y), word[2::], font=font, fill=colours[word[1]], anchor=anchor)
+            x += w
+        return x
 
 
 def interpolate_color(start_color, end_color, percentage):

--- a/Helpers/storage.py
+++ b/Helpers/storage.py
@@ -56,7 +56,9 @@ class S3Storage:
         try:
             with telemetry.track("s3.get"):
                 resp = self.client.get_object(Bucket=self._bucket, Key=key)
-                return resp["Body"].read()
+                data = resp["Body"].read()
+                resp["Body"].close()
+                return data
         except Exception:
             return None
 

--- a/Helpers/storage.py
+++ b/Helpers/storage.py
@@ -16,6 +16,7 @@ from botocore.exceptions import ClientError
 from PIL import Image
 
 from Helpers.logger import log, WARN, ERROR
+from Helpers import telemetry
 
 AVATAR_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days
 
@@ -53,8 +54,9 @@ class S3Storage:
         if not self._is_configured:
             return None
         try:
-            resp = self.client.get_object(Bucket=self._bucket, Key=key)
-            return resp["Body"].read()
+            with telemetry.track("s3.get"):
+                resp = self.client.get_object(Bucket=self._bucket, Key=key)
+                return resp["Body"].read()
         except Exception:
             return None
 
@@ -69,24 +71,26 @@ class S3Storage:
         if not self._is_configured:
             return None
         try:
-            resp = self.client.get_object(Bucket=self._bucket, Key=key)
-            age = (datetime.now(timezone.utc) - resp["LastModified"]).total_seconds()
-            if age > max_age_seconds:
+            with telemetry.track("s3.get"):
+                resp = self.client.get_object(Bucket=self._bucket, Key=key)
+                age = (datetime.now(timezone.utc) - resp["LastModified"]).total_seconds()
+                if age > max_age_seconds:
+                    resp["Body"].close()
+                    return None
+                data = resp["Body"].read()
                 resp["Body"].close()
-                return None
-            data = resp["Body"].read()
-            resp["Body"].close()
-            return data
+                return data
         except Exception:
             return None
 
     def put_bytes(self, key: str, data: bytes, content_type: str = "image/png"):
-        self.client.put_object(
-            Bucket=self._bucket,
-            Key=key,
-            Body=data,
-            ContentType=content_type,
-        )
+        with telemetry.track("s3.put"):
+            self.client.put_object(
+                Bucket=self._bucket,
+                Key=key,
+                Body=data,
+                ContentType=content_type,
+            )
 
     def put_image(self, key: str, image: Image.Image):
         buf = io.BytesIO()

--- a/Helpers/telemetry.py
+++ b/Helpers/telemetry.py
@@ -116,7 +116,10 @@ def track(bucket: str):
         yield
         return
 
-    start = time.perf_counter()
+    # Only the outermost span for a bucket records, so skip the clock reads
+    # entirely when nested — this timer sits on the instrumented hot paths
+    # (render primitives call each other) and shouldn't add its own overhead.
+    start = time.perf_counter() if depth == 0 else None
     try:
         yield
     finally:

--- a/Helpers/telemetry.py
+++ b/Helpers/telemetry.py
@@ -1,0 +1,150 @@
+"""
+Helpers/telemetry.py
+Phase 0 latency instrumentation. Emits one JSON object per line on stdout.
+
+This module deliberately does NOT route through Helpers/logger.py. That logger
+queues messages to a Discord channel; per-command telemetry there would spam the
+channel and add Discord API calls to the very code path being measured.
+
+Nothing here may raise into a caller. A telemetry bug must never be able to break
+a command.
+"""
+
+import contextvars
+import json
+import os
+import sys
+import time
+from contextlib import contextmanager
+
+# Holds the accumulator for the in-flight command invocation.
+#
+# Code MUTATES the Sample rather than rebinding this variable. asyncio.to_thread
+# copies the context into the worker thread, so a rebind there would be invisible
+# to the caller, whereas a mutation of the shared object is visible. Much of this
+# codebase's blocking work is already threaded, so this distinction matters.
+_current: contextvars.ContextVar = contextvars.ContextVar("telemetry_sample", default=None)
+
+_DISABLED_VALUES = ("0", "false", "no")
+
+
+def enabled() -> bool:
+    return os.getenv("LATENCY_TELEMETRY", "1").strip().lower() not in _DISABLED_VALUES
+
+
+class Sample:
+    """Timing accumulator for a single command invocation."""
+
+    def __init__(self, command, guild_id=None, user_id=None, queue_ms=None):
+        self.command = command
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.queue_ms = queue_ms
+        self.started = time.perf_counter()
+        self.buckets = {}
+        # Per-bucket nesting depth, so nested spans are not counted twice.
+        self.depth = {}
+
+    def add(self, bucket, seconds):
+        ms = seconds * 1000.0
+        entry = self.buckets.get(bucket)
+        if entry is None:
+            self.buckets[bucket] = {"n": 1, "ms": round(ms, 2)}
+        else:
+            entry["n"] += 1
+            entry["ms"] = round(entry["ms"] + ms, 2)
+
+    def payload(self, ok):
+        return {
+            "type": "command",
+            "command": self.command,
+            "guild_id": self.guild_id,
+            "user_id": self.user_id,
+            "queue_ms": self.queue_ms,
+            "total_ms": round((time.perf_counter() - self.started) * 1000.0, 2),
+            "ok": ok,
+            "buckets": self.buckets,
+        }
+
+
+def emit(payload: dict) -> None:
+    """Write one JSON line to stdout. Never raises."""
+    if not enabled():
+        return
+    try:
+        payload.setdefault("ts", round(time.time(), 3))
+        sys.stdout.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+
+def record(bucket: str, seconds: float) -> None:
+    """Add a duration to the current invocation. No-op outside one. Never raises."""
+    try:
+        sample = _current.get()
+        if sample is not None:
+            sample.add(bucket, seconds)
+    except Exception:
+        pass
+
+
+@contextmanager
+def track(bucket: str):
+    """Time a block into `bucket`.
+
+    Depth-guarded: when spans for the same bucket nest, only the outermost one
+    records. The render primitives call each other, so without this the render
+    total would be inflated by double counting.
+
+    Records even when the body raises, then lets the exception propagate: slow
+    failures are as interesting as slow successes.
+    """
+    try:
+        sample = _current.get()
+    except Exception:
+        sample = None
+
+    if sample is None:
+        yield
+        return
+
+    try:
+        depth = sample.depth.get(bucket, 0)
+        sample.depth[bucket] = depth + 1
+    except Exception:
+        yield
+        return
+
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        try:
+            sample.depth[bucket] = depth
+            if depth == 0:
+                sample.add(bucket, time.perf_counter() - start)
+        except Exception:
+            pass
+
+
+def begin(command, guild_id=None, user_id=None, queue_ms=None):
+    """Start an invocation. Never raises."""
+    try:
+        sample = Sample(command, guild_id, user_id, queue_ms)
+        _current.set(sample)
+        return sample
+    except Exception:
+        return None
+
+
+def finish(ok: bool = True) -> None:
+    """Emit the current invocation's record and clear it. Never raises."""
+    try:
+        sample = _current.get()
+        if sample is None:
+            return
+        _current.set(None)
+        emit(sample.payload(ok))
+    except Exception:
+        pass

--- a/Tasks/loop_lag.py
+++ b/Tasks/loop_lag.py
@@ -56,16 +56,18 @@ class LoopLag(commands.Cog):
         self._last = now
 
     def _emit_summary(self, now):
+        # Emit every window, even one with no positive-drift samples, so the
+        # summary is a reliable once-a-minute heartbeat: absence of a line then
+        # means the monitor (or the loop) is dead, not merely a quiet window.
         samples = sorted(self._samples)
-        if samples:
-            telemetry.emit({
-                "type": "loop_lag_summary",
-                "window_s": round(now - self._window_started, 1),
-                "n": len(samples),
-                "p50_ms": round(_percentile(samples, 0.50), 2),
-                "p95_ms": round(_percentile(samples, 0.95), 2),
-                "max_ms": round(samples[-1], 2),
-            })
+        telemetry.emit({
+            "type": "loop_lag_summary",
+            "window_s": round(now - self._window_started, 1),
+            "n": len(samples),
+            "p50_ms": round(_percentile(samples, 0.50), 2),
+            "p95_ms": round(_percentile(samples, 0.95), 2),
+            "max_ms": round(samples[-1], 2) if samples else 0.0,
+        })
         self._samples = []
         self._window_started = now
 

--- a/Tasks/loop_lag.py
+++ b/Tasks/loop_lag.py
@@ -1,0 +1,78 @@
+"""
+Tasks/loop_lag.py
+Event-loop scheduling drift monitor.
+
+A 1-second loop that measures how late it actually wakes up. Drift is a direct
+measure of how long the event loop was blocked, which is the discriminator for
+the hypothesis that commands queue behind blocking work in the background tasks.
+
+Individual excursions over the threshold are emitted as they happen; everything
+else is folded into a once-a-minute summary, which keeps this at roughly 1,400
+lines a day rather than 86,000.
+"""
+
+import time
+
+from discord.ext import commands, tasks
+
+from Helpers import telemetry
+
+INTERVAL_S = 1.0
+LAG_THRESHOLD_MS = 250.0
+SUMMARY_INTERVAL_S = 60.0
+
+
+def _percentile(sorted_samples, q):
+    """Nearest-rank percentile over an already-sorted list."""
+    if not sorted_samples:
+        return 0.0
+    idx = int(round(q * (len(sorted_samples) - 1)))
+    idx = max(0, min(len(sorted_samples) - 1, idx))
+    return sorted_samples[idx]
+
+
+class LoopLag(commands.Cog):
+    def __init__(self, client):
+        self.client = client
+        self._last = None
+        self._samples = []
+        self._window_started = time.perf_counter()
+        self.loop_lag.start()
+
+    def cog_unload(self):
+        self.loop_lag.cancel()
+
+    @tasks.loop(seconds=INTERVAL_S)
+    async def loop_lag(self):
+        now = time.perf_counter()
+        if self._last is not None:
+            drift_ms = (now - self._last - INTERVAL_S) * 1000.0
+            if drift_ms > 0:
+                self._samples.append(drift_ms)
+                if drift_ms >= LAG_THRESHOLD_MS:
+                    telemetry.emit({"type": "loop_lag", "drift_ms": round(drift_ms, 2)})
+            if now - self._window_started >= SUMMARY_INTERVAL_S:
+                self._emit_summary(now)
+        self._last = now
+
+    def _emit_summary(self, now):
+        samples = sorted(self._samples)
+        if samples:
+            telemetry.emit({
+                "type": "loop_lag_summary",
+                "window_s": round(now - self._window_started, 1),
+                "n": len(samples),
+                "p50_ms": round(_percentile(samples, 0.50), 2),
+                "p95_ms": round(_percentile(samples, 0.95), 2),
+                "max_ms": round(samples[-1], 2),
+            })
+        self._samples = []
+        self._window_started = now
+
+    @loop_lag.before_loop
+    async def before_loop_lag(self):
+        await self.client.wait_until_ready()
+
+
+def setup(client):
+    client.add_cog(LoopLag(client))

--- a/docs/latency-investigation.md
+++ b/docs/latency-investigation.md
@@ -1,6 +1,6 @@
 # Command latency investigation
 
-**Status:** parked. Investigation only — no code changes made. Pick up at [Phase 0](#phase-0--measure-first) when this becomes a priority.
+**Status:** Phase 0 instrumentation is implemented (measurement only, behaviourally neutral). It has not yet been analysed — deploy, capture a data window, then work through [Reading the telemetry](#reading-the-telemetry). Phase 1 (the fixes) has not been started.
 
 ## Symptom
 
@@ -68,23 +68,71 @@ These are worth fixing regardless of which hypothesis wins.
    fetches the avatar synchronously, hits S3 synchronously, and renders the Pillow card inline.
    This stalls the gateway heartbeat, not just other commands.
 3. **No shared HTTP session.** There is no keep-alive anywhere in the outbound path.
-4. **No latency instrumentation.** Nothing measures where time goes, so everything above is
-   inference rather than measurement. This is the real blocker.
+4. **No latency instrumentation.** Nothing measured where time goes, so everything above is
+   inference rather than measurement. This is the gap Phase 0 closes.
 
 ## Plan
 
-### Phase 0 — measure first
+### Phase 0 — measure (implemented)
 
-Do not fix anything until these land and produce a deploy cycle's worth of data.
+Instrumentation is in place. It is measurement-only and behaviourally neutral: it wraps existing
+code and times it, changing no runtime behaviour, so the numbers form a valid baseline to judge
+Phase 1 against. Toggle with the `LATENCY_TELEMETRY` env var — any of `0` / `false` / `no`
+(case-insensitive) disables it; default on.
 
-- **Event-loop lag monitor.** A one-second task recording scheduling drift. If lag spikes into the
-  seconds on the three-minute boundary, H1 is confirmed and the rest is secondary.
-- **Per-command timing.** Wrap command invocation to log total wall time, split by boundary:
-  database connect vs. query, each outbound host, S3, render.
-- **Correlation.** Line slow commands up against task-loop start times. `update_member_data`
-  already logs a loop-start marker.
+What it emits — one JSON line per record to **stdout** (deliberately not the Discord log channel,
+so it never spams `#logs`):
 
-Estimated at well under a hundred lines.
+- `command` — one per slash-command invocation: `queue_ms` (the gap between Discord creating the
+  interaction and the bot starting to run it), `total_ms`, `ok`, and `buckets` splitting time by
+  `db.connect` / `db.query` / `db.commit` / `http.<host>` / `s3.get` / `s3.put` / `render`.
+- `loop_lag` — emitted whenever a single one-second tick drifts more than 250 ms.
+- `loop_lag_summary` — once a minute: p50 / p95 / max drift.
+- `probe` — only when `scripts/latency_probe.py` is run by hand (idle → cold timings → warm
+  timings → delta). Read-only, and not part of the deployed bot.
+
+Scope limits to keep in mind when reading the data:
+
+- Timing records are **command-scoped**. Background task loops call the same DB and HTTP layers but
+  run outside any command, so their own calls emit no bucket record. Their impact shows up
+  indirectly, through `loop_lag` and through `queue_ms` on commands that land mid-cycle.
+- A few `requests.get` calls inside individual command files (snipe, worlds, lootpool, manage,
+  raids, map, progress) are not routed through the timed wrapper, so their HTTP time appears in no
+  `http.*` bucket. The shared hot paths are covered; the picture is not exhaustive.
+- A command cancelled mid-flight (shutdown, gateway disconnect) records `ok: true`, because
+  py-cord swallows the cancellation before the timing hook runs. Documented, not fixed.
+
+### Reading the telemetry
+
+Read stdout in this order:
+
+1. `loop_lag_summary` p95 first. Seconds-scale drift means the event loop is being blocked — direct
+   support for H1.
+2. `queue_ms` outliers on `command` records, cross-referenced against task-loop start times
+   (`update_member_data` logs a `STARTING LOOP` marker).
+3. Only if those look clean, the `buckets` split on the slowest `command` records.
+4. `scripts/latency_probe.py --idle-minutes 10` (or more), run separately, to settle H2 on its own
+   terms: it runs with no event loop and no task loops, so a cold/warm delta there is attributable
+   to connections going cold rather than to loop contention.
+
+The decision that falls out: whether Phase 1 needs the task fleet split off the event loop (H1), or
+whether pooling and HTTP session reuse are enough (H2).
+
+### Capturing the data (Railway retention)
+
+Railway keeps logs for a limited window by plan — 7 days on Hobby, 30 on Pro. Telemetry lands on
+the same stdout stream as the normal logs, interleaved; filter with
+`railway logs | grep '"type":' | jq`.
+
+Two consequences:
+
+- The measurement window must fit inside retention. This is an active, bounded measurement (cycles
+  are minutes-to-hours apart, so a couple of days suffices), so 7 days is enough — but don't deploy
+  and leave it; the early data ages out.
+- Anything worth keeping past the window — in particular the baseline run to diff Phase 1 against —
+  must be pulled down deliberately: `railway logs > phase0-baseline.jsonl` during the run, or
+  forward logs to an external sink (Railway suggests Vector / Fluent Bit / OTEL). For a one-off
+  investigation, teeing to a file is enough; a forwarder is overkill.
 
 ### Phase 1 — fixes, highest payoff first
 
@@ -98,6 +146,8 @@ Estimated at well under a hundred lines.
 
 ## Picking this back up
 
-Start at Phase 0. The single highest-information measurement is the event-loop lag monitor: it
-either confirms or kills H1 in one deploy, and that decides whether Phase 1 step 4 is needed at
-all.
+Phase 0 is built and deployed-ready; the next action is to run it and read the output, not to write
+more code. Deploy, let it run through several quiet-then-active cycles, capture the window before it
+ages out, then work through [Reading the telemetry](#reading-the-telemetry). The single
+highest-information signal is the event-loop lag monitor: it either confirms or kills H1, and that
+decides whether Phase 1's task-fleet split is needed at all.

--- a/docs/latency-investigation.md
+++ b/docs/latency-investigation.md
@@ -1,0 +1,103 @@
+# Command latency investigation
+
+**Status:** parked. Investigation only — no code changes made. Pick up at [Phase 0](#phase-0--measure-first) when this becomes a priority.
+
+## Symptom
+
+After a quiet period, the first slash command takes a very long time to return. Subsequent
+commands are noticeably faster for a while, then the slowness returns. The pattern reads as
+something "going to sleep" and needing to wake up.
+
+## Architecture snapshot
+
+Single Railway **worker** service — one process, one event loop, one persistent Discord gateway
+socket (see `Procfile`, `main.py`). No public port.
+
+| Dependency | Access pattern | Entry point |
+|---|---|---|
+| Neon Postgres (pooler endpoint) | psycopg2, one connect+close **per helper call** | `DB` in `Helpers/database.py` |
+| Supabase Storage (S3 API) | boto3, lazily-created singleton client | `S3Storage` in `Helpers/storage.py` |
+| Wynncraft v3 / Mojang / visage / Athena | blocking `requests.get`, new session per call | `Helpers/functions.py`, `Guild` in `Helpers/classes.py` |
+| OpenAI, Google Sheets | blocking | `Helpers/openai_helper.py`, `Helpers/sheets.py` |
+
+Sharing that one event loop: the command cogs in `Commands/`, the task loops in `Tasks/`
+(intervals from 10s to daily), and Pillow card rendering.
+
+## Ruled out
+
+The "something is asleep" model does not survive the evidence:
+
+- **Neon autosuspend.** `Tasks/territory_tracker.py` runs on a 10-second loop and opens two fresh
+  Neon connections per pass (`_read_territories_sync`, `saveTerritoryData`). Autosuspend requires
+  several minutes of zero compute activity. The database never gets there.
+- **Railway app sleep.** Sleep applies to HTTP-triggered services. This is a worker with no public
+  port and a permanently open gateway socket. If sleep were active the bot would disconnect
+  outright rather than merely slow down.
+- **In-process caches expiring.** The `lru_cache` font cache and UUID/name cache in
+  `Helpers/functions.py`, and the Athena guild-colour cache in `Commands/snipe.py`, live for the
+  process lifetime or hours. None of them cycle on the timescale of the reported symptom.
+
+## Hypotheses, ranked
+
+**H1 — Event-loop contention with the background task fleet.** *(best fit)*
+The task loops in `Tasks/` run on 1/2/3/5/10-minute cycles and several perform blocking work
+directly on the event loop. A command arriving mid-cycle queues behind that work; one arriving in
+a gap returns immediately. The apparent sleep/wake periodicity is the task schedule.
+`Tasks/update_member_data.py` is the prime suspect — it runs every three minutes and iterates the
+full guild roster.
+
+**H2 — Cold connection paths after idle.** *(contributing)*
+Every database helper opens a fresh TLS connection to Neon. Every outbound API call builds a new
+`requests` session, so nothing reuses a socket. botocore's connection pool idles out. Under
+sustained traffic some of this amortises; after a quiet spell everything re-handshakes at once. A
+single `/profile` invocation can open several Neon connections and several TLS sessions.
+
+**H3 — Upstream edge-cache misses.** *(external)*
+A cold Wynncraft API cache for a given player accounts for part of the first-call cost. Not
+fixable here; worth measuring so it can be subtracted from the budget.
+
+## Structural problems found
+
+These are worth fixing regardless of which hypothesis wins.
+
+1. **No database connection pool.** Every helper in `Helpers/database.py` constructs a `DB`,
+   connects, and closes. One command can pay that cost five or more times. A process-lifetime
+   `ThreadedConnectionPool` (or a move to `psycopg_pool`) removes it.
+2. **Blocking I/O on the event loop.** Many `requests.get` call sites live in `Commands/`.
+   `Commands/profile.py` is representative: it correctly moves `PlayerStats` to a thread, then
+   fetches the avatar synchronously, hits S3 synchronously, and renders the Pillow card inline.
+   This stalls the gateway heartbeat, not just other commands.
+3. **No shared HTTP session.** There is no keep-alive anywhere in the outbound path.
+4. **No latency instrumentation.** Nothing measures where time goes, so everything above is
+   inference rather than measurement. This is the real blocker.
+
+## Plan
+
+### Phase 0 — measure first
+
+Do not fix anything until these land and produce a deploy cycle's worth of data.
+
+- **Event-loop lag monitor.** A one-second task recording scheduling drift. If lag spikes into the
+  seconds on the three-minute boundary, H1 is confirmed and the rest is secondary.
+- **Per-command timing.** Wrap command invocation to log total wall time, split by boundary:
+  database connect vs. query, each outbound host, S3, render.
+- **Correlation.** Line slow commands up against task-loop start times. `update_member_data`
+  already logs a loop-start marker.
+
+Estimated at well under a hundred lines.
+
+### Phase 1 — fixes, highest payoff first
+
+1. Connection pool in `DB`. Single file, removes N handshakes per command.
+2. Move remaining blocking work off the loop: module-level `requests.Session`, and `to_thread` for
+   the Pillow render and the S3 calls.
+3. Stagger task-loop start offsets so they do not all fire on the same minute boundary.
+4. Split the task fleet into its own service or process so background work cannot contend with
+   interaction handling. This is the real fix for H1 and the largest change — only worth doing if
+   Phase 0 confirms H1.
+
+## Picking this back up
+
+Start at Phase 0. The single highest-information measurement is the event-loop lag monitor: it
+either confirms or kills H1 in one deploy, and that decides whether Phase 1 step 4 is needed at
+all.

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from Helpers.database import get_last_online, set_last_online
 from Helpers.variables import IS_TEST_MODE, ERROR_CHANNEL_ID, PUBLIC_COMMANDS, ERROR_PING_USER_ID
 from Helpers.logger import log, SYSTEM, SUCCESS, ERROR, INFO
 from Helpers import logger
+from Helpers import telemetry
 from Commands.generate import ApplicationButtonView
 from Helpers.views import ApplicationVoteView, ThreadVoteView
 
@@ -119,6 +120,39 @@ async def on_connect():
         "timestamp": int(time.time())
     }
     set_last_online(last_online)
+
+
+@client.before_invoke
+async def _telemetry_before(ctx: discord.ApplicationContext):
+    """Start a timing accumulator for this invocation.
+
+    queue_ms is the gap between Discord creating the interaction and the bot
+    starting to run it — it separates "the bot was busy" from "the work was slow".
+    """
+    queue_ms = None
+    try:
+        created = ctx.interaction.created_at
+        now = datetime.datetime.now(datetime.timezone.utc)
+        queue_ms = round((now - created).total_seconds() * 1000.0, 2)
+    except Exception:
+        pass
+
+    telemetry.begin(
+        ctx.command.qualified_name if ctx.command else "unknown",
+        guild_id=ctx.guild.id if ctx.guild else None,
+        user_id=ctx.author.id if ctx.author else None,
+        queue_ms=queue_ms,
+    )
+
+
+@client.after_invoke
+async def _telemetry_after(ctx: discord.ApplicationContext):
+    """Emit the invocation record.
+
+    py-cord calls this from a `finally`, so it also runs for failed commands;
+    sys.exc_info() is how we tell the two apart.
+    """
+    telemetry.finish(ok=sys.exc_info()[0] is None)
 
 
 @client.event

--- a/main.py
+++ b/main.py
@@ -280,6 +280,7 @@ extensions = [
     'Tasks.sync_war_builds',
     'Tasks.daily_musing',
     'Tasks.annihilation_announcements',
+    'Tasks.loop_lag',
 ]
 
 for ext in extensions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ openai>=1.75.0
 PyNaCl>=1.5.0
 boto3>=1.34.0
 certifi>=2024.1.0
+pytest>=8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ PyNaCl>=1.5.0
 boto3>=1.34.0
 certifi>=2024.1.0
 pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/scripts/latency_probe.py
+++ b/scripts/latency_probe.py
@@ -1,0 +1,108 @@
+"""
+scripts/latency_probe.py
+Cold-path latency repro harness.
+
+Idles, then times each dependency, then immediately times them again warm, and
+prints the delta. Runs with no event loop and no background task loops, which is
+what makes it useful: a cold/warm delta here is attributable to connection paths
+going cold, not to commands queueing behind blocking work in the bot.
+
+Read-only. A SELECT, some GETs, an S3 read, and an in-memory render.
+
+Usage:
+    python scripts/latency_probe.py --idle-minutes 10
+    python scripts/latency_probe.py --idle-minutes 0   # warm-only, for iterating
+"""
+
+import argparse
+import os
+import sys
+import time
+
+from dotenv import load_dotenv
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Helpers import telemetry
+from Helpers.classes import Guild
+from Helpers.database import DB
+from Helpers.functions import round_corners, vertical_gradient
+from Helpers.storage import get_background
+
+
+def _time(label, fn):
+    start = time.perf_counter()
+    error = None
+    try:
+        fn()
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+    return label, round((time.perf_counter() - start) * 1000.0, 2), error
+
+
+def _db_select():
+    db = DB()
+    db.connect()
+    try:
+        db.cursor.execute("SELECT 1")
+        db.cursor.fetchone()
+    finally:
+        db.close()
+
+
+def _wynn_fetch():
+    Guild("The Aquarium")
+
+
+def _s3_read():
+    get_background(1)
+
+
+def _render():
+    round_corners(vertical_gradient(width=850, height=1130))
+
+
+STEPS = [
+    ("db", _db_select),
+    ("wynncraft", _wynn_fetch),
+    ("s3", _s3_read),
+    ("render", _render),
+]
+
+
+def run_phase(phase):
+    results = {}
+    for label, fn in STEPS:
+        label, ms, error = _time(label, fn)
+        results[label] = ms
+        telemetry.emit({"type": "probe", "phase": phase, "step": label, "ms": ms, "error": error})
+        status = f"  {label:<12} {ms:>9.2f} ms"
+        print(status if error is None else f"{status}   ERROR {error}")
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--idle-minutes", type=float, default=10.0,
+                        help="minutes to idle before the cold pass (default: 10)")
+    args = parser.parse_args()
+
+    load_dotenv()
+
+    if args.idle_minutes > 0:
+        print(f"Idling {args.idle_minutes} minutes so connection paths go cold...")
+        time.sleep(args.idle_minutes * 60.0)
+
+    print("\nCOLD")
+    cold = run_phase("cold")
+
+    print("\nWARM")
+    warm = run_phase("warm")
+
+    print("\nDELTA (cold - warm)")
+    for label, _ in STEPS:
+        print(f"  {label:<12} {cold[label] - warm[label]:>9.2f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_database_timing.py
+++ b/tests/test_database_timing.py
@@ -1,0 +1,98 @@
+"""
+Test suite for DB timing proxies (Helpers/database.py).
+
+Tests:
+1. execute() is timed into db.query
+2. Non-timed cursor methods delegate unchanged
+3. commit() is timed into db.commit
+4. Non-timed connection methods delegate unchanged
+5. A raising execute() still records and re-raises
+"""
+
+import os
+import sys
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Helpers import telemetry
+from Helpers.database import _TimedConnection, _TimedCursor
+
+
+@pytest.fixture(autouse=True)
+def _reset_context():
+    token = telemetry._current.set(None)
+    yield
+    telemetry._current.reset(token)
+
+
+class FakeCursor:
+    def __init__(self):
+        self.executed = []
+        self.closed = False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchone(self):
+        return ("row",)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConnection:
+    def __init__(self):
+        self.committed = False
+        self.closed = False
+
+    def commit(self):
+        self.committed = True
+
+    def close(self):
+        self.closed = True
+
+
+def test_execute_is_timed_into_db_query():
+    telemetry.begin("test", None, None, None)
+    cursor = _TimedCursor(FakeCursor())
+    cursor.execute("SELECT 1", None)
+    assert telemetry._current.get().buckets["db.query"]["n"] == 1
+
+
+def test_cursor_delegates_untimed_methods():
+    inner = FakeCursor()
+    cursor = _TimedCursor(inner)
+    assert cursor.fetchone() == ("row",)
+    cursor.close()
+    assert inner.closed is True
+
+
+def test_commit_is_timed_into_db_commit():
+    telemetry.begin("test", None, None, None)
+    inner = FakeConnection()
+    connection = _TimedConnection(inner)
+    connection.commit()
+    assert inner.committed is True
+    assert telemetry._current.get().buckets["db.commit"]["n"] == 1
+
+
+def test_connection_delegates_untimed_methods():
+    inner = FakeConnection()
+    connection = _TimedConnection(inner)
+    connection.close()
+    assert inner.closed is True
+
+
+def test_failing_execute_records_and_reraises():
+    class Boom:
+        def execute(self, *args, **kwargs):
+            raise RuntimeError("bad sql")
+
+    telemetry.begin("test", None, None, None)
+    cursor = _TimedCursor(Boom())
+    with pytest.raises(RuntimeError, match="bad sql"):
+        cursor.execute("SELECT 1")
+    assert telemetry._current.get().buckets["db.query"]["n"] == 1

--- a/tests/test_loop_lag.py
+++ b/tests/test_loop_lag.py
@@ -1,0 +1,48 @@
+"""
+Test suite for the event-loop lag monitor (Tasks/loop_lag.py).
+
+Tests:
+1. Percentile selection on known inputs
+2. Percentile on an empty list
+3. Summary emission shape and bucket clearing
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Tasks import loop_lag
+
+
+def test_percentile_picks_expected_values():
+    samples = [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert loop_lag._percentile(samples, 0.0) == 1.0
+    assert loop_lag._percentile(samples, 0.5) == 3.0
+    assert loop_lag._percentile(samples, 1.0) == 5.0
+
+
+def test_percentile_on_empty_list_returns_zero():
+    assert loop_lag._percentile([], 0.5) == 0.0
+
+
+def test_emit_summary_shape_and_reset(monkeypatch, capsys):
+    monkeypatch.setenv("LATENCY_TELEMETRY", "1")
+
+    cog = loop_lag.LoopLag.__new__(loop_lag.LoopLag)
+    cog._samples = [10.0, 20.0, 500.0]
+    cog._window_started = 0.0
+
+    cog._emit_summary(60.0)
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["type"] == "loop_lag_summary"
+    assert payload["n"] == 3
+    assert payload["max_ms"] == 500.0
+    assert payload["window_s"] == 60.0
+    assert cog._samples == []
+    assert cog._window_started == 60.0

--- a/tests/test_loop_lag.py
+++ b/tests/test_loop_lag.py
@@ -50,6 +50,27 @@ def test_emit_summary_shape_and_reset(monkeypatch, capsys):
     assert cog._window_started == 60.0
 
 
+def test_emit_summary_on_empty_window_is_a_heartbeat(monkeypatch, capsys):
+    """A window with no positive-drift samples still emits a summary with n=0,
+    so the once-a-minute line is a reliable liveness signal."""
+    monkeypatch.setenv("LATENCY_TELEMETRY", "1")
+
+    cog = loop_lag.LoopLag.__new__(loop_lag.LoopLag)
+    cog._samples = []
+    cog._window_started = 0.0
+
+    cog._emit_summary(60.0)
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["type"] == "loop_lag_summary"
+    assert payload["n"] == 0
+    assert payload["p50_ms"] == 0.0
+    assert payload["p95_ms"] == 0.0
+    assert payload["max_ms"] == 0.0
+    assert cog._samples == []
+    assert cog._window_started == 60.0
+
+
 def test_first_tick_is_noop(monkeypatch):
     """With no prior tick recorded, one tick must not compute drift or emit."""
     monkeypatch.setattr(loop_lag.time, "perf_counter", lambda: 100.0)

--- a/tests/test_loop_lag.py
+++ b/tests/test_loop_lag.py
@@ -7,9 +7,11 @@ Tests:
 3. Summary emission shape and bucket clearing
 """
 
+import asyncio
 import json
 import os
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -46,3 +48,76 @@ def test_emit_summary_shape_and_reset(monkeypatch, capsys):
     assert payload["window_s"] == 60.0
     assert cog._samples == []
     assert cog._window_started == 60.0
+
+
+def test_first_tick_is_noop(monkeypatch):
+    """With no prior tick recorded, one tick must not compute drift or emit."""
+    monkeypatch.setattr(loop_lag.time, "perf_counter", lambda: 100.0)
+
+    mock_emit = MagicMock()
+    monkeypatch.setattr(loop_lag.telemetry, "emit", mock_emit)
+
+    cog = loop_lag.LoopLag.__new__(loop_lag.LoopLag)
+    cog._last = None
+    cog._samples = []
+    cog._window_started = 100.0
+
+    asyncio.run(cog.loop_lag())
+
+    assert cog._samples == []
+    assert cog._last == 100.0
+    mock_emit.assert_not_called()
+
+
+def test_sub_threshold_drift_accumulates_silently(monkeypatch):
+    """Positive drift below the threshold is recorded but not emitted."""
+    sub_threshold_drift_ms = loop_lag.LAG_THRESHOLD_MS / 2.0
+    clock = [0.0, loop_lag.INTERVAL_S + sub_threshold_drift_ms / 1000.0]
+    monkeypatch.setattr(loop_lag.time, "perf_counter", lambda: clock.pop(0))
+
+    mock_emit = MagicMock()
+    monkeypatch.setattr(loop_lag.telemetry, "emit", mock_emit)
+
+    cog = loop_lag.LoopLag.__new__(loop_lag.LoopLag)
+    cog._last = None
+    cog._samples = []
+    cog._window_started = 0.0
+
+    async def run_two_ticks():
+        await cog.loop_lag()
+        await cog.loop_lag()
+
+    asyncio.run(run_two_ticks())
+
+    assert len(cog._samples) == 1
+    assert cog._samples[0] == pytest.approx(sub_threshold_drift_ms, abs=1.0)
+    assert cog._samples[0] < loop_lag.LAG_THRESHOLD_MS
+    assert not any(
+        call.args[0].get("type") == "loop_lag" for call in mock_emit.call_args_list
+    )
+
+
+def test_drift_at_or_above_threshold_emits_loop_lag_record(monkeypatch):
+    """Drift at/above the threshold emits exactly one loop_lag record."""
+    over_threshold_drift_ms = loop_lag.LAG_THRESHOLD_MS + 10.0
+    clock = [0.0, loop_lag.INTERVAL_S + over_threshold_drift_ms / 1000.0]
+    monkeypatch.setattr(loop_lag.time, "perf_counter", lambda: clock.pop(0))
+
+    mock_emit = MagicMock()
+    monkeypatch.setattr(loop_lag.telemetry, "emit", mock_emit)
+
+    cog = loop_lag.LoopLag.__new__(loop_lag.LoopLag)
+    cog._last = None
+    cog._samples = []
+    cog._window_started = 0.0
+
+    async def run_two_ticks():
+        await cog.loop_lag()
+        await cog.loop_lag()
+
+    asyncio.run(run_two_ticks())
+
+    mock_emit.assert_called_once()
+    payload = mock_emit.call_args[0][0]
+    assert payload["type"] == "loop_lag"
+    assert payload["drift_ms"] >= loop_lag.LAG_THRESHOLD_MS - 1e-6

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -154,3 +154,31 @@ def test_finish_marks_failure(monkeypatch, capsys):
     import json
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["ok"] is False
+
+
+def test_cancellation_is_not_visible_to_after_hook():
+    """py-cord's hooked_wrapped_callback catches asyncio.CancelledError and
+    `return`s before its `finally` block runs, so sys.exc_info() is already
+    (None, None, None) by the time the after-hook fires there.
+
+    This means `_telemetry_after`'s `ok = sys.exc_info()[0] is None` derivation
+    records a cancelled command invocation as ok=True -- the opposite of the
+    ordinary-raise case pinned by test_sys_exc_info_is_visible_inside_async_finally.
+    This is a known, accepted limitation: a cancelled command's timing record is
+    truncated regardless, so the mislabeled `ok` is not being fixed.
+    """
+    seen = {}
+
+    async def body():
+        try:
+            raise asyncio.CancelledError()
+        except asyncio.CancelledError:
+            return
+        finally:
+            seen["exc"] = sys.exc_info()[0]
+
+    async def main():
+        await body()
+
+    asyncio.run(main())
+    assert seen["exc"] is None

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -119,3 +119,38 @@ def test_finish_emits_one_json_line(monkeypatch, capsys):
     assert payload["queue_ms"] == 12.5
     assert payload["ok"] is True
     assert payload["buckets"]["db.query"]["n"] == 1
+
+
+def test_sys_exc_info_is_visible_inside_async_finally():
+    """py-cord runs after_invoke inside a `finally` while an exception propagates.
+
+    `ok` is derived from sys.exc_info() there, so pin that semantic down.
+    """
+    seen = {}
+
+    async def hook():
+        await asyncio.sleep(0)
+        seen["exc"] = sys.exc_info()[0]
+
+    async def body():
+        try:
+            raise ValueError("boom")
+        finally:
+            await hook()
+
+    async def main():
+        with pytest.raises(ValueError):
+            await body()
+
+    asyncio.run(main())
+    assert seen["exc"] is ValueError
+
+
+def test_finish_marks_failure(monkeypatch, capsys):
+    monkeypatch.setenv("LATENCY_TELEMETRY", "1")
+    telemetry.begin("profile", None, None, None)
+    telemetry.finish(ok=False)
+
+    import json
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is False

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,121 @@
+"""
+Test suite for Phase 0 latency telemetry (Helpers/telemetry.py).
+
+Tests:
+1. Accumulation: repeated track() on one bucket sums duration and counts calls
+2. Depth guarding: nested track() on the same bucket records the outer span only
+3. Context isolation: concurrent invocations do not contaminate each other
+4. Thread propagation: track() inside asyncio.to_thread reaches the caller's sample
+5. Exceptions: a raising body still records, and the exception propagates
+6. No-op: track() outside an invocation does nothing and does not raise
+7. Kill switch: emit() writes nothing when disabled
+"""
+
+import asyncio
+import os
+import sys
+import time
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Helpers import telemetry
+
+
+@pytest.fixture(autouse=True)
+def _reset_context():
+    token = telemetry._current.set(None)
+    yield
+    telemetry._current.reset(token)
+
+
+def test_track_accumulates_count_and_duration():
+    telemetry.begin("test", None, None, None)
+    for _ in range(2):
+        with telemetry.track("db.query"):
+            time.sleep(0.01)
+    bucket = telemetry._current.get().buckets["db.query"]
+    assert bucket["n"] == 2
+    assert bucket["ms"] >= 18.0
+
+
+def test_nested_track_records_outer_span_only():
+    telemetry.begin("test", None, None, None)
+    with telemetry.track("render"):
+        time.sleep(0.01)
+        with telemetry.track("render"):
+            time.sleep(0.01)
+    bucket = telemetry._current.get().buckets["render"]
+    assert bucket["n"] == 1
+    assert bucket["ms"] >= 18.0
+
+
+def test_concurrent_invocations_do_not_share_buckets():
+    async def invocation(name, bucket):
+        telemetry.begin(name, None, None, None)
+        with telemetry.track(bucket):
+            await asyncio.sleep(0.01)
+        return telemetry._current.get()
+
+    async def main():
+        return await asyncio.gather(
+            invocation("a", "db.query"),
+            invocation("b", "s3.get"),
+        )
+
+    a, b = asyncio.run(main())
+    assert set(a.buckets) == {"db.query"}
+    assert set(b.buckets) == {"s3.get"}
+
+
+def test_track_propagates_into_to_thread():
+    def blocking():
+        with telemetry.track("db.connect"):
+            time.sleep(0.01)
+
+    async def main():
+        telemetry.begin("test", None, None, None)
+        await asyncio.to_thread(blocking)
+        return telemetry._current.get()
+
+    sample = asyncio.run(main())
+    assert sample.buckets["db.connect"]["n"] == 1
+
+
+def test_track_records_and_reraises_on_exception():
+    telemetry.begin("test", None, None, None)
+    with pytest.raises(ValueError, match="boom"):
+        with telemetry.track("http.example.com"):
+            raise ValueError("boom")
+    assert telemetry._current.get().buckets["http.example.com"]["n"] == 1
+
+
+def test_track_outside_invocation_is_noop():
+    with telemetry.track("db.query"):
+        pass  # must not raise
+
+
+def test_emit_respects_kill_switch(monkeypatch, capsys):
+    monkeypatch.setenv("LATENCY_TELEMETRY", "0")
+    telemetry.emit({"type": "command"})
+    assert capsys.readouterr().out == ""
+
+
+def test_finish_emits_one_json_line(monkeypatch, capsys):
+    monkeypatch.setenv("LATENCY_TELEMETRY", "1")
+    telemetry.begin("profile", 1, 2, 12.5)
+    with telemetry.track("db.query"):
+        pass
+    telemetry.finish(ok=True)
+
+    import json
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["type"] == "command"
+    assert payload["command"] == "profile"
+    assert payload["queue_ms"] == 12.5
+    assert payload["ok"] is True
+    assert payload["buckets"]["db.query"]["n"] == 1

--- a/tests/test_timed_get.py
+++ b/tests/test_timed_get.py
@@ -1,0 +1,43 @@
+"""
+Test suite for outbound HTTP timing (Helpers/functions.timed_get).
+
+Tests:
+1. Timing lands in a bucket named for the URL's host
+2. The response object is returned unchanged
+3. A URL with no parseable host uses the 'unknown' bucket
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Helpers import telemetry
+from Helpers.functions import timed_get
+
+
+@pytest.fixture(autouse=True)
+def _reset_context():
+    token = telemetry._current.set(None)
+    yield
+    telemetry._current.reset(token)
+
+
+def test_timed_get_buckets_by_host():
+    telemetry.begin("test", None, None, None)
+    with patch("Helpers.functions.requests.get", return_value="response") as mock_get:
+        result = timed_get("https://api.wynncraft.com/v3/player/x", timeout=10)
+    assert result == "response"
+    mock_get.assert_called_once_with("https://api.wynncraft.com/v3/player/x", timeout=10)
+    assert telemetry._current.get().buckets["http.api.wynncraft.com"]["n"] == 1
+
+
+def test_timed_get_without_host_uses_unknown():
+    telemetry.begin("test", None, None, None)
+    with patch("Helpers.functions.requests.get", return_value="response"):
+        timed_get("not-a-url")
+    assert telemetry._current.get().buckets["http.unknown"]["n"] == 1


### PR DESCRIPTION
## What this is

Phase 0 of the command-latency investigation: **instrumentation only, behaviourally neutral.** Slash commands are slow after idle periods and nothing measured where the time goes. This branch adds that measurement so the fix (Phase 1) can be judged against a real baseline. It wraps existing code and times it — no connection pool, no shared HTTP session, no moving blocking work off the loop, no task-loop reordering. Those are Phase 1.

## What's in it

- **`Helpers/telemetry.py`** — per-invocation timing accumulator in a `ContextVar` (survives `asyncio.to_thread`), depth-guarded `track()` context manager, and `emit()` writing one JSON line per record to **stdout** (never the Discord log channel). Kill switch: `LATENCY_TELEMETRY` env var, default on.
- **`main.py`** — global `before_invoke`/`after_invoke` hooks emitting a `command` record per invocation with `queue_ms` (interaction-created → bot-starts gap) and a per-layer `buckets` split.
- **`Tasks/loop_lag.py`** — 1s event-loop drift monitor: excursions over 250ms plus a per-minute p50/p95/max summary.
- **Chokepoint timing** across the shared layers — `db.connect`/`db.query`/`db.commit` (`Helpers/database.py`), `s3.get`/`s3.put` (`Helpers/storage.py`), `http.<host>` and `render` (`Helpers/functions.py`).
- **`scripts/latency_probe.py`** — standalone read-only cold/warm repro harness (not run by the bot) that isolates the cold-connection hypothesis by running with no event loop.
- **`requirements.txt`** — adds `pytest` + `pytest-asyncio` (the existing test suite was never actually runnable without the latter).
- **`docs/latency-investigation.md`** — the investigation writeup, updated with how to read the telemetry and how to capture a baseline before Railway's log retention rolls it off.

## After deploy

Deploy, let it run through a few quiet-then-active cycles, then read stdout: `loop_lag_summary` p95 → `queue_ms` outliers vs. task-loop starts → `buckets` on the slowest commands → run the probe with a real idle. That decides whether Phase 1 is "split the task fleet off the event loop" or "add pooling + session reuse". Reading order and the retention/capture note are in the doc.

## Tests

68 passed (1 pre-existing `audioop` DeprecationWarning from `discord`, not introduced here). Includes the 35 async tests that had never been runnable before `pytest-asyncio` was declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
