### PR TITLE
Latency: queue_ms fix, telemetry analyzer, Phase 1 speedups

### DIFF
--- a/Commands/aspects.py
+++ b/Commands/aspects.py
@@ -21,7 +21,6 @@ from Helpers.functions import getNameFromUUID
 from Helpers.variables import EXEC_GUILD_IDS, IS_TEST_MODE
 from Helpers.logger import log, WARN, ERROR
 from Helpers import aspect_db
-from Helpers.storage import get_cached_avatar, save_cached_avatar
 MAX_COLUMNS = 4
 ROWS_PER_COLUMN = 10
 CELL_WIDTH = 205
@@ -62,10 +61,6 @@ class AspectDistribution(commands.Cog):
         return buf.read()
 
     async def get_avatar(self, uuid: str) -> bytes:
-        cached = get_cached_avatar(uuid)
-        if cached:
-            return cached
-
         url = f"https://vzge.me/face/64/{uuid}"
         headers = {'User-Agent': os.getenv("visage_UA", "")}
         try:
@@ -88,7 +83,6 @@ class AspectDistribution(commands.Cog):
                         log(WARN, f"Invalid image data received for UUID {uuid}", context="aspects")
                         return None
 
-            save_cached_avatar(uuid, data)
             return data
         except Exception as e:
             log(WARN, f"Failed to fetch avatar for UUID {uuid}: {e}", context="aspects")

--- a/Commands/lootpool.py
+++ b/Commands/lootpool.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import discord
-import requests
 from discord.ext import commands
 from discord.commands import SlashCommandGroup
 from datetime import datetime, timezone, timedelta
@@ -894,13 +893,13 @@ class LootPool(commands.Cog):
 
         raw_resp, gambit_resp = await asyncio.gather(
             asyncio.to_thread(
-                requests.get,
+                timed_get,
                 f"{self.WYNNVENTORY_BASE_URL}/api/raidpool/items",
                 headers=self._wynnventory_headers,
                 timeout=15,
             ),
             asyncio.to_thread(
-                requests.get,
+                timed_get,
                 f"{self.WYNNVENTORY_BASE_URL}/api/raidpool/gambits/current",
                 headers=self._wynnventory_headers,
                 timeout=15,

--- a/Commands/lootpool.py
+++ b/Commands/lootpool.py
@@ -10,7 +10,7 @@ from PIL import Image, ImageDraw, ImageFont
 from io import BytesIO
 from Helpers.variables import mythics, WYNNVENTORY_API_KEY
 from Helpers.rate_limiter import external_rate_limit
-from Helpers.functions import wrap_text, get_multiline_text_size
+from Helpers.functions import wrap_text, get_multiline_text_size, timed_get
 from Helpers.database import DB
 from Helpers.logger import log, ERROR
 import os
@@ -298,7 +298,7 @@ class LootPool(commands.Cog):
         return {"Authorization": f"Api-Key {WYNNVENTORY_API_KEY}"}
 
     def _fetch_lootpool_data(self) -> list:
-        resp = requests.get(
+        resp = timed_get(
             f"{self.WYNNVENTORY_BASE_URL}/api/lootpool/items",
             headers=self._wynnventory_headers,
             timeout=15,
@@ -308,7 +308,7 @@ class LootPool(commands.Cog):
 
     def _fetch_ward_map(self) -> dict[str, list[str]]:
         try:
-            resp = requests.get(
+            resp = timed_get(
                 f"{self.OFFICIAL_API_BASE_URL}/v3/map/loot-pools",
                 timeout=10,
             )

--- a/Commands/manage.py
+++ b/Commands/manage.py
@@ -8,11 +8,10 @@ from discord import SlashCommandGroup, ApplicationContext
 from discord.ext import commands
 from discord.ui import Modal, InputText
 from PIL import Image, ImageDraw, ImageFont, ImageOps
-import requests
 
 from Helpers.classes import LinkAccount, PlayerStats, PlayerShells
 from Helpers.database import DB
-from Helpers.functions import addLine, split_sentence, expand_image, getPlayerUUID
+from Helpers.functions import addLine, split_sentence, expand_image, getPlayerUUID, timed_get
 from Helpers.logger import log, ERROR
 from Helpers.variables import HOME_GUILD_IDS, discord_ranks, discord_rank_roles
 
@@ -40,7 +39,7 @@ class ShellModalName(Modal):
         player = PlayerStats(self.children[0].value, 1, False)
         try:
             url = f"https://visage.surgeplay.com/bust/75/{player.UUID}"
-            skin = Image.open(BytesIO(requests.get(url).content))
+            skin = Image.open(BytesIO(timed_get(url).content))
         except:
             skin = Image.open('images/profile/x-steve.webp')
         img.paste(skin, (10, 10), skin)
@@ -231,7 +230,7 @@ class Manage(commands.Cog):
             try:
                 headers = {'User-Agent': os.getenv("visage_UA")}
                 url = f"https://visage.surgeplay.com/bust/75/{player.UUID}"
-                skin = Image.open(BytesIO(requests.get(url, headers=headers).content))
+                skin = Image.open(BytesIO(timed_get(url, headers=headers).content))
             except:
                 skin = Image.open('images/profile/X-Steve.webp')
 

--- a/Commands/manage.py
+++ b/Commands/manage.py
@@ -75,6 +75,77 @@ def _build_shell_modal_card(ign, operation, amount, reason, user_id):
     return discord.File(buf, filename=f"shell_{int(time.time())}.png")
 
 
+def _rank_lookup(invoker_id, target_id):
+    """Fetch the invoker's rank, the target's rank, and the target's ign rows
+    in one short checkout. Blocking DB read — call via asyncio.to_thread."""
+    db = DB(); db.connect()
+    try:
+        db.cursor.execute(
+            "SELECT rank FROM discord_links WHERE discord_id = %s", (invoker_id,)
+        )
+        inv = db.cursor.fetchone()
+        db.cursor.execute(
+            "SELECT rank FROM discord_links WHERE discord_id = %s", (target_id,)
+        )
+        tgt = db.cursor.fetchone()
+        db.cursor.execute(
+            "SELECT ign FROM discord_links WHERE discord_id = %s", (target_id,)
+        )
+        rows = db.cursor.fetchall()
+        return inv, tgt, rows
+    finally:
+        db.close()
+
+
+def _rank_update(target_id, rank):
+    """Persist a rank change. Blocking DB write — call via asyncio.to_thread."""
+    db = DB(); db.connect()
+    try:
+        db.cursor.execute(
+            "UPDATE discord_links SET rank = %s WHERE discord_id = %s",
+            (rank, target_id)
+        )
+        db.connection.commit()
+    finally:
+        db.close()
+
+
+def _link_user(user_id, ign, base_nick):
+    """Resolve the ign's UUID (HTTP first — no checkout held across it), then
+    upsert the discord link. Blocking — call via asyncio.to_thread.
+
+    Returns 'updated' or 'linked', or None when the ign cannot be resolved."""
+    player_data = getPlayerUUID(ign)
+    if not player_data:
+        return None
+    uuid = player_data[1]
+
+    db = DB(); db.connect()
+    try:
+        db.cursor.execute(
+            "SELECT * FROM discord_links WHERE discord_id = %s", (user_id,)
+        )
+        if db.cursor.fetchone():
+            db.cursor.execute(
+                "UPDATE discord_links SET ign = %s, uuid = %s WHERE discord_id = %s",
+                (ign, uuid, user_id)
+            )
+            db.cursor.execute(
+                "INSERT INTO shells (\"user\") VALUES (%s) ON CONFLICT DO NOTHING",
+                (str(user_id),)
+            )
+            db.connection.commit()
+            return 'updated'
+        db.cursor.execute(
+            "INSERT INTO discord_links (discord_id, ign, uuid, linked, rank) VALUES (%s,%s,%s,False,%s)",
+            (user_id, ign, uuid, base_nick)
+        )
+        db.connection.commit()
+        return 'linked'
+    finally:
+        db.close()
+
+
 def _shells_lookup(user_id):
     """Return the discord_links rows for a user (used to decide render vs modal).
     Blocking DB read — call via asyncio.to_thread."""
@@ -224,96 +295,72 @@ class Manage(commands.Cog):
         user: discord.Member,
         rank: discord.Option(str, choices=list(discord_ranks.keys()))
     ):
-        db = DB(); db.connect()
-        try:
-            # Fetch invoker and target ranks
-            db.cursor.execute(
-                "SELECT rank FROM discord_links WHERE discord_id = %s",
-                (ctx.user.id,)
-            )
-            inv = db.cursor.fetchone()
-            if not inv:
-                await ctx.respond(':no_entry: You must link your account before assigning ranks.', ephemeral=True)
-                return
-            initiator_rank = inv[0]
-            initiator_index = list(discord_ranks).index(initiator_rank)
+        # One short checkout for all three reads; permission math is pure and
+        # runs here. No pool slot is held across the role-edit awaits below.
+        inv, tgt, rows = await asyncio.to_thread(_rank_lookup, ctx.user.id, user.id)
 
-            # Prevent self-assignment
-            if user.id == ctx.user.id:
-                await ctx.respond(':no_entry: You cannot change your own rank.', ephemeral=True)
-                return
+        if not inv:
+            await ctx.respond(':no_entry: You must link your account before assigning ranks.', ephemeral=True)
+            return
+        initiator_rank = inv[0]
+        initiator_index = list(discord_ranks).index(initiator_rank)
 
-            db.cursor.execute(
-                "SELECT rank FROM discord_links WHERE discord_id = %s",
-                (user.id,)
-            )
-            tgt = db.cursor.fetchone()
-            if not tgt:
-                # Let the existing modal handle linking
-                rows = True
-            else:
-                current_rank = tgt[0]
-                target_index = list(discord_ranks).index(current_rank)
-                if target_index >= initiator_index:
-                    await ctx.respond(':no_entry: You can only change ranks for members below your own.', ephemeral=True)
-                    return
+        # Prevent self-assignment
+        if user.id == ctx.user.id:
+            await ctx.respond(':no_entry: You cannot change your own rank.', ephemeral=True)
+            return
 
-            # Validate that the chosen new rank is below the initiator's rank
-            new_rank_index = list(discord_ranks).index(rank)
-            if new_rank_index >= initiator_index:
-                await ctx.respond(':no_entry: You cannot assign a rank equal to or above your own.', ephemeral=True)
+        if tgt:
+            current_rank = tgt[0]
+            target_index = list(discord_ranks).index(current_rank)
+            if target_index >= initiator_index:
+                await ctx.respond(':no_entry: You can only change ranks for members below your own.', ephemeral=True)
                 return
 
-            # Proceed with role updates
-            db.cursor.execute(
-                "SELECT ign FROM discord_links WHERE discord_id = %s", (user.id,)
+        # Validate that the chosen new rank is below the initiator's rank
+        new_rank_index = list(discord_ranks).index(rank)
+        if new_rank_index >= initiator_index:
+            await ctx.respond(':no_entry: You cannot assign a rank equal to or above your own.', ephemeral=True)
+            return
+
+        added = 'Added Roles:'
+        removed = 'Removed Roles:'
+        all_roles = ctx.guild.roles
+
+        if rows:
+            await ctx.defer(ephemeral=True)
+            # Apply new rank roles
+            for role_name in discord_ranks[rank]['roles']:
+                role_obj = discord.utils.get(all_roles, name=role_name)
+                if role_obj and role_obj not in user.roles:
+                    await user.add_roles(role_obj)
+                    added += f"\n - {role_name}"
+            # Remove old rank roles
+            for role_name in [r for r in discord_rank_roles if r not in discord_ranks[rank]['roles']]:
+                role_obj = discord.utils.get(all_roles, name=role_name)
+                if role_obj and role_obj in user.roles:
+                    await user.remove_roles(role_obj)
+                    removed += f"\n - {role_name}"
+            # Persist the rank change (its own brief checkout)
+            await asyncio.to_thread(_rank_update, user.id, rank)
+            # Update nickname
+            try:
+                current = user.nick or user.name
+                parts = current.split(' ', 1)
+                base = parts[1] if len(parts) > 1 else parts[0]
+                await user.edit(nick=f"{rank} {base}")
+            except:
+                pass
+            await ctx.followup.send(f"{added}\n\n{removed}", ephemeral=True)
+        else:
+            modal = LinkAccount(
+                title="Link User to Minecraft IGN",
+                user=user,
+                rank=rank,
+                added=added,
+                removed=removed
             )
-            rows = db.cursor.fetchall()
-
-            added = 'Added Roles:'
-            removed = 'Removed Roles:'
-            all_roles = ctx.guild.roles
-
-            if rows:
-                await ctx.defer(ephemeral=True)
-                # Apply new rank roles
-                for role_name in discord_ranks[rank]['roles']:
-                    role_obj = discord.utils.get(all_roles, name=role_name)
-                    if role_obj and role_obj not in user.roles:
-                        await user.add_roles(role_obj)
-                        added += f"\n - {role_name}"
-                # Remove old rank roles
-                for role_name in [r for r in discord_rank_roles if r not in discord_ranks[rank]['roles']]:
-                    role_obj = discord.utils.get(all_roles, name=role_name)
-                    if role_obj and role_obj in user.roles:
-                        await user.remove_roles(role_obj)
-                        removed += f"\n - {role_name}"
-                # Update DB
-                db.cursor.execute(
-                    "UPDATE discord_links SET rank = %s WHERE discord_id = %s",
-                    (rank, user.id)
-                )
-                db.connection.commit()
-                # Update nickname
-                try:
-                    current = user.nick or user.name
-                    parts = current.split(' ', 1)
-                    base = parts[1] if len(parts) > 1 else parts[0]
-                    await user.edit(nick=f"{rank} {base}")
-                except:
-                    pass
-                await ctx.followup.send(f"{added}\n\n{removed}", ephemeral=True)
-            else:
-                modal = LinkAccount(
-                    title="Link User to Minecraft IGN",
-                    user=user,
-                    rank=rank,
-                    added=added,
-                    removed=removed
-                )
-                await ctx.interaction.response.send_modal(modal)
-        finally:
-            db.close()
+            await ctx.interaction.response.send_modal(modal)
 
     @manage_group.command(name='shells', description='HR: Add or remove shells from a user')
     async def shells(
@@ -352,21 +399,17 @@ class Manage(commands.Cog):
         ign: str
     ):
         await ctx.defer(ephemeral=True)
-        db = DB(); db.connect()
-        uuid = getPlayerUUID(ign)[1]
-        db.cursor.execute(
-            "SELECT * FROM discord_links WHERE discord_id = %s", (user.id,)
-        )
-        if db.cursor.fetchone():
-            db.cursor.execute(
-                "UPDATE discord_links SET ign = %s, uuid = %s WHERE discord_id = %s",
-                (ign, uuid, user.id)
+        base = (user.nick.split(' ')[0] if user.nick else '')
+        result = await asyncio.to_thread(_link_user, user.id, ign, base)
+
+        if result is None:
+            # Previously getPlayerUUID(ign)[1] crashed with TypeError on a
+            # failed lookup; fail with a clear message instead.
+            await ctx.followup.send(
+                f':no_entry: Could not resolve **{ign}** — check the spelling and try again.',
+                ephemeral=True
             )
-            db.cursor.execute(
-                "INSERT INTO shells (\"user\") VALUES (%s) ON CONFLICT DO NOTHING",
-                (str(user.id),)
-            )
-            db.connection.commit()
+        elif result == 'updated':
             try:
                 base = user.nick.split(' ')[0]
                 await user.edit(nick=f"{base} {ign}")
@@ -377,17 +420,10 @@ class Manage(commands.Cog):
                 ephemeral=True
             )
         else:
-            base = (user.nick.split(' ')[0] if user.nick else '')
-            db.cursor.execute(
-                "INSERT INTO discord_links (discord_id, ign, uuid, linked, rank) VALUES (%s,%s,%s,False,%s)",
-                (user.id, ign, uuid, base)
-            )
-            db.connection.commit()
             await ctx.followup.send(
                 f'Linked **{user.name}** to **{ign}**',
                 ephemeral=True
             )
-        db.close()
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/Commands/manage.py
+++ b/Commands/manage.py
@@ -1,5 +1,6 @@
 import os
 import time
+import asyncio
 from datetime import datetime
 from io import BytesIO
 
@@ -14,6 +15,154 @@ from Helpers.database import DB
 from Helpers.functions import addLine, split_sentence, expand_image, getPlayerUUID, timed_get
 from Helpers.logger import log, ERROR
 from Helpers.variables import HOME_GUILD_IDS, discord_ranks, discord_rank_roles
+
+
+def _build_shell_modal_card(ign, operation, amount, reason, user_id):
+    """Build the shell-adjustment card for the link-and-set modal path, and
+    write the resulting link/balance rows. Blocking (HTTP + Pillow + DB) —
+    always call via asyncio.to_thread so it never stalls the event loop."""
+    player = PlayerStats(ign, 1, False)
+
+    img = Image.new('RGBA', (375, 95), '#100010e2')
+    draw = ImageDraw.Draw(img); draw.fontmode = '1'
+    font = ImageFont.truetype('images/profile/game.ttf', 19)
+
+    try:
+        url = f"https://visage.surgeplay.com/bust/75/{player.UUID}"
+        skin = Image.open(BytesIO(timed_get(url).content))
+    except:
+        skin = Image.open('images/profile/x-steve.webp')
+    img.paste(skin, (10, 10), skin)
+
+    if operation == 'add':
+        new_amount = player.shells + amount
+        diff = f'+{amount}'
+    else:
+        new_amount = player.shells - amount
+        diff = f'-{amount}'
+    addLine(f'&7All-Time: &f{new_amount} &7({diff}&7)', draw, font, 95, 61)
+
+    # Connect only now that all external HTTP has completed.
+    db = DB(); db.connect()
+    try:
+        db.cursor.execute(
+            "INSERT INTO discord_links (discord_id, ign, linked, rank) VALUES (%s, %s, 0, '') ON CONFLICT (discord_id) DO UPDATE SET ign=EXCLUDED.ign;",
+            (user_id, ign)
+        )
+        db.cursor.execute(
+            "INSERT INTO shells (\"user\", shells) VALUES (%s, %s) ON CONFLICT (\"user\") DO UPDATE SET shells=EXCLUDED.shells;",
+            (str(user_id), new_amount)
+        )
+        db.connection.commit()
+    finally:
+        db.close()
+
+    addLine(f'&f{player.username}', draw, font, 95, 15)
+    addLine(f'&7Balance: &f{new_amount} &7({diff}&7)', draw, font, 95, 40)
+
+    if reason:
+        for line in split_sentence(reason):
+            img, draw = expand_image(img)
+            addLine(f'&3{line}', draw, font, 10, img.height - 25)
+
+    img = ImageOps.expand(img, border=(2, 2), fill='#100010e2')
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((2, 2, img.width - 3, img.height - 3), outline='#240059', width=2)
+
+    buf = BytesIO(); img.save(buf, 'PNG'); buf.seek(0)
+    return discord.File(buf, filename=f"shell_{int(time.time())}.png")
+
+
+def _shells_lookup(user_id):
+    """Return the discord_links rows for a user (used to decide render vs modal).
+    Blocking DB read — call via asyncio.to_thread."""
+    db = DB(); db.connect()
+    try:
+        db.cursor.execute(
+            "SELECT ign FROM discord_links WHERE discord_id = %s", (user_id,)
+        )
+        return db.cursor.fetchall()
+    finally:
+        db.close()
+
+
+def _build_shells_card(user_id, ign, operation, amount, actor_name, actor_id):
+    """Build the shell-adjustment card for the /manage shells render path, and
+    apply the balance + audit writes. Blocking (HTTP + Pillow + DB) — always
+    call via asyncio.to_thread so it never stalls the event loop."""
+    player = PlayerShells(user_id)
+
+    img = Image.new('RGBA', (375, 95), '#100010e2')
+    draw = ImageDraw.Draw(img); draw.fontmode = '1'
+    font = ImageFont.truetype('images/profile/game.ttf', 19)
+
+    try:
+        headers = {'User-Agent': os.getenv("visage_UA")}
+        url = f"https://visage.surgeplay.com/bust/75/{player.UUID}"
+        skin = Image.open(BytesIO(timed_get(url, headers=headers).content))
+    except:
+        skin = Image.open('images/profile/X-Steve.webp')
+    img.paste(skin, (10, 10), skin)
+
+    # Connect only now that all external HTTP has completed.
+    db = DB(); db.connect()
+    try:
+        # Ensure user exists in shells table
+        db.cursor.execute('SELECT shells, balance FROM shells WHERE "user" = %s', (str(user_id),))
+        row2 = db.cursor.fetchone()
+
+        if row2:
+            current_shells, current_balance = row2
+        else:
+            current_shells, current_balance = 0, 0
+            db.cursor.execute(
+                'INSERT INTO shells ("user", shells, balance, ign) VALUES (%s, %s, %s, %s)',
+                (str(user_id), 0, 0, ign)
+            )
+            db.connection.commit()
+
+        if operation == 'add':
+            new_total = current_shells + amount
+            new_balance = current_balance + amount
+            diff = f'+{amount}'
+            db.cursor.execute(
+                'UPDATE shells SET shells = %s, balance = %s, ign = %s WHERE "user" = %s',
+                (new_total, new_balance, ign, str(user_id))
+            )
+        else:
+            new_balance = current_balance - amount
+            diff = f'-{amount}'
+            db.cursor.execute(
+                'UPDATE shells SET balance = %s, ign = %s WHERE "user" = %s',
+                (new_balance, ign, str(user_id))
+            )
+            new_total = current_shells
+
+        addLine(f'&f{player.username}', draw, font, 95, 15)
+        addLine(f'&7Balance: &f{new_balance} &7({diff}&7)', draw, font, 95, 40)
+        if operation == 'add':
+            addLine(f'&7All-Time: &f{new_total} &7({diff}&7)', draw, font, 95, 61)
+        else:
+            addLine(f'&7All-Time: &f{new_total}', draw, font, 95, 61)
+
+        db.connection.commit()
+
+        try:
+            db.cursor.execute(
+                "INSERT INTO audit_log (log_type, actor_name, actor_id, action) VALUES (%s, %s, %s, %s)",
+                ('shell', actor_name, actor_id, f'{operation}ed {amount} to {player.username}.')
+            )
+            db.connection.commit()
+        except Exception as e:
+            log(ERROR, f"audit_log write failed: {e}", context="manage")
+    finally:
+        db.close()
+
+    img = ImageOps.expand(img, border=(2, 2), fill='#100010e2')
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((2, 2, img.width - 3, img.height - 3), outline='#240059', width=2)
+    buf = BytesIO(); img.save(buf, 'PNG'); buf.seek(0)
+    return discord.File(buf, filename=f"shells_{int(time.time())}.png")
 
 
 class ShellModalName(Modal):
@@ -31,53 +180,16 @@ class ShellModalName(Modal):
         )
 
     async def callback(self, interaction: discord.Interaction):
-        db = DB(); db.connect()
-        img = Image.new('RGBA', (375, 95), '#100010e2')
-        draw = ImageDraw.Draw(img); draw.fontmode = '1'
-        font = ImageFont.truetype('images/profile/game.ttf', 19)
-
-        player = PlayerStats(self.children[0].value, 1, False)
-        try:
-            url = f"https://visage.surgeplay.com/bust/75/{player.UUID}"
-            skin = Image.open(BytesIO(timed_get(url).content))
-        except:
-            skin = Image.open('images/profile/x-steve.webp')
-        img.paste(skin, (10, 10), skin)
-
-        if self.operation == 'add':
-            new_amount = player.shells + self.amount
-            diff = f'+{self.amount}'
-        else:
-            new_amount = player.shells - self.amount
-            diff = f'-{self.amount}'
-        addLine(f'&7All-Time: &f{new_amount} &7({diff}&7)', draw, font, 95, 61)
-
-        db.cursor.execute(
-            "INSERT INTO discord_links (discord_id, ign, linked, rank) VALUES (%s, %s, 0, '') ON CONFLICT (discord_id) DO UPDATE SET ign=EXCLUDED.ign;",
-            (self.user.id, self.children[0].value)
+        await interaction.response.defer()
+        file = await asyncio.to_thread(
+            _build_shell_modal_card,
+            self.children[0].value,
+            self.operation,
+            self.amount,
+            self.reason,
+            self.user.id,
         )
-        db.cursor.execute(
-            "INSERT INTO shells (\"user\", shells) VALUES (%s, %s) ON CONFLICT (\"user\") DO UPDATE SET shells=EXCLUDED.shells;",
-            (str(self.user.id), new_amount)
-        )
-        db.connection.commit()
-
-        addLine(f'&f{player.username}', draw, font, 95, 15)
-        addLine(f'&7Balance: &f{new_amount} &7({diff}&7)', draw, font, 95, 40)
-
-        if self.reason:
-            for line in split_sentence(self.reason):
-                img, draw = expand_image(img)
-                addLine(f'&3{line}', draw, font, 10, img.height - 25)
-
-        img = ImageOps.expand(img, border=(2,2), fill='#100010e2')
-        draw = ImageDraw.Draw(img)
-        draw.rectangle((2,2,img.width-3,img.height-3), outline='#240059', width=2)
-
-        buf = BytesIO(); img.save(buf, 'PNG'); buf.seek(0)
-        file = discord.File(buf, filename=f"shell_{int(time.time())}.png")
-        await interaction.response.send_message(file=file)
-        db.close()
+        await interaction.followup.send(file=file)
 
 
 class Manage(commands.Cog):
@@ -198,84 +310,14 @@ class Manage(commands.Cog):
         amount: int,
         # reason: discord.Option(str, required=False, default='')
     ):
-        db = DB(); db.connect()
-        db.cursor.execute(
-            "SELECT ign FROM discord_links WHERE discord_id = %s", (user.id,)
-        )
-        rows = db.cursor.fetchall()
+        rows = await asyncio.to_thread(_shells_lookup, user.id)
 
         if rows:
             await ctx.defer()
             ign = rows[0][0]
-
-            # Ensure user exists in shells table
-            db.cursor.execute('SELECT shells, balance FROM shells WHERE "user" = %s', (str(user.id),))
-            row2 = db.cursor.fetchone()
-
-            if row2:
-                current_shells, current_balance = row2
-            else:
-                current_shells, current_balance = 0, 0
-                db.cursor.execute(
-                    'INSERT INTO shells ("user", shells, balance, ign) VALUES (%s, %s, %s, %s)',
-                    (str(user.id), 0, 0, ign)
-                )
-                db.connection.commit()
-
-            player = PlayerShells(user.id)
-            img = Image.new('RGBA', (375, 95), '#100010e2')
-            draw = ImageDraw.Draw(img); draw.fontmode = '1'
-            font = ImageFont.truetype('images/profile/game.ttf', 19)
-
-            try:
-                headers = {'User-Agent': os.getenv("visage_UA")}
-                url = f"https://visage.surgeplay.com/bust/75/{player.UUID}"
-                skin = Image.open(BytesIO(timed_get(url, headers=headers).content))
-            except:
-                skin = Image.open('images/profile/X-Steve.webp')
-
-            img.paste(skin, (10, 10), skin)
-
-            if operation == 'add':
-                new_total = current_shells + amount
-                new_balance = current_balance + amount
-                diff = f'+{amount}'
-                db.cursor.execute(
-                    'UPDATE shells SET shells = %s, balance = %s, ign = %s WHERE "user" = %s',
-                    (new_total, new_balance, ign, str(user.id))
-                )
-            else:
-                new_balance = current_balance - amount
-                diff = f'-{amount}'
-                db.cursor.execute(
-                    'UPDATE shells SET balance = %s, ign = %s WHERE "user" = %s',
-                    (new_balance, ign, str(user.id))
-                )
-                new_total = current_shells
-
-            addLine(f'&f{player.username}', draw, font, 95, 15)
-            addLine(f'&7Balance: &f{new_balance} &7({diff}&7)', draw, font, 95, 40)
-            if operation == 'add':
-                addLine(f'&7All-Time: &f{new_total} &7({diff}&7)', draw, font, 95, 61)
-            else:
-                addLine(f'&7All-Time: &f{new_total}', draw, font, 95, 61)
-
-            db.connection.commit()
-
-            try:
-                db.cursor.execute(
-                    "INSERT INTO audit_log (log_type, actor_name, actor_id, action) VALUES (%s, %s, %s, %s)",
-                    ('shell', ctx.user.name, ctx.user.id, f'{operation}ed {amount} to {player.username}.')
-                )
-                db.connection.commit()
-            except Exception as e:
-                log(ERROR, f"audit_log write failed: {e}", context="manage")
-
-            img = ImageOps.expand(img, border=(2,2), fill='#100010e2')
-            draw = ImageDraw.Draw(img)
-            draw.rectangle((2, 2, img.width - 3, img.height - 3), outline='#240059', width=2)
-            buf = BytesIO(); img.save(buf, 'PNG'); buf.seek(0)
-            file = discord.File(buf, filename=f"shells_{int(time.time())}.png")
+            file = await asyncio.to_thread(
+                _build_shells_card, user.id, ign, operation, amount, ctx.user.name, ctx.user.id
+            )
             await ctx.followup.send(file=file)
         else:
             modal = ShellModalName(
@@ -287,7 +329,6 @@ class Manage(commands.Cog):
                 reason=''
             )
             await ctx.interaction.response.send_modal(modal)
-        db.close()
 
     @manage_group.command(name='link', description='HR: Link a user to an IGN')
     async def link(

--- a/Commands/manage.py
+++ b/Commands/manage.py
@@ -22,6 +22,8 @@ def _build_shell_modal_card(ign, operation, amount, reason, user_id):
     write the resulting link/balance rows. Blocking (HTTP + Pillow + DB) —
     always call via asyncio.to_thread so it never stalls the event loop."""
     player = PlayerStats(ign, 1, False)
+    if player.error:
+        raise ValueError(f"could not retrieve player data for '{ign}'")
 
     img = Image.new('RGBA', (375, 95), '#100010e2')
     draw = ImageDraw.Draw(img); draw.fontmode = '1'
@@ -180,15 +182,27 @@ class ShellModalName(Modal):
         )
 
     async def callback(self, interaction: discord.Interaction):
+        # Modal errors route to Modal.on_error (stderr), not the command error
+        # handler — an unhandled raise here would strand the deferred
+        # interaction at "thinking…" forever. Report failures ourselves.
         await interaction.response.defer()
-        file = await asyncio.to_thread(
-            _build_shell_modal_card,
-            self.children[0].value,
-            self.operation,
-            self.amount,
-            self.reason,
-            self.user.id,
-        )
+        try:
+            file = await asyncio.to_thread(
+                _build_shell_modal_card,
+                self.children[0].value,
+                self.operation,
+                self.amount,
+                self.reason,
+                self.user.id,
+            )
+        except Exception as e:
+            log(ERROR, f"Shell modal card failed for '{self.children[0].value}': {e}", context="manage")
+            await interaction.followup.send(
+                f"⚠️ Could not process shells for `{self.children[0].value}`. "
+                "Check the name and try again.",
+                ephemeral=True,
+            )
+            return
         await interaction.followup.send(file=file)
 
 

--- a/Commands/map.py
+++ b/Commands/map.py
@@ -2,12 +2,12 @@ import discord
 from discord.ext import commands
 from discord.commands import slash_command, Option
 from Helpers.rate_limiter import external_rate_limit
+from Helpers.functions import timed_get
 from PIL import Image, ImageDraw, ImageFont
 from datetime import datetime, timezone
 from io import BytesIO
 import asyncio
 import json
-import requests
 from typing import Tuple, Optional
 
 
@@ -29,14 +29,14 @@ def mapCreator(guild_prefix: Optional[str] = None):
 
     # Build a map of guild prefix to color
     try:
-        guilds_data = requests.get("https://athena.wynntils.com/cache/get/guildList", timeout=10).json()
+        guilds_data = timed_get("https://athena.wynntils.com/cache/get/guildList", timeout=10).json()
         color_map = {g["prefix"]: g.get("color", "#FFFFFF") for g in guilds_data if g.get("prefix")}
     except Exception:
         color_map = {}
 
     # Fetch territory data
     try:
-        territory_data = requests.get("https://api.wynncraft.com/v3/guild/list/territory", timeout=10).json()
+        territory_data = timed_get("https://api.wynncraft.com/v3/guild/list/territory", timeout=10).json()
     except Exception:
         territory_data = {}
 

--- a/Commands/new_member.py
+++ b/Commands/new_member.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import discord
 from discord.ext import commands
 from discord.commands import slash_command
@@ -9,6 +11,22 @@ from Helpers.functions import getPlayerUUID, determine_starting_rank
 from Helpers.variables import HOME_GUILD_IDS, discord_ranks
 
 
+def _fetch_new_member_data(user_id, ign):
+    """Fetch the player's stats and existing link rows for registration.
+    Blocking (HTTP + DB read) — always call via asyncio.to_thread. The DB is
+    checked out only after the BasicPlayerStats HTTP has completed."""
+    pdata = BasicPlayerStats(ign)
+
+    db = DB(); db.connect()
+    try:
+        db.cursor.execute('SELECT * FROM discord_links WHERE discord_id = %s', (user_id,))
+        rows = db.cursor.fetchall()
+    finally:
+        db.close()
+
+    return rows, pdata
+
+
 class NewMember(commands.Cog):
     def __init__(self, client):
         self.client = client
@@ -17,12 +35,8 @@ class NewMember(commands.Cog):
     @default_permissions(manage_roles=True)
     async def new_member(self, message, user: discord.Member, ign):
         if message.interaction.user.guild_permissions.manage_roles:
-            db = DB()
-            db.connect()
-            db.cursor.execute('SELECT * FROM discord_links WHERE discord_id = %s', (user.id,))
-            rows = db.cursor.fetchall()
             await message.defer(ephemeral=True)
-            pdata = BasicPlayerStats(ign)
+            rows, pdata = await asyncio.to_thread(_fetch_new_member_data, user.id, ign)
             if pdata.error:
                 embed = discord.Embed(title=':no_entry: Oops! Something did not go as intended.',
                                       description=f'Could not retrieve information of `{ign}`.\nPlease check your spelling or try again later.',
@@ -77,17 +91,20 @@ class NewMember(commands.Cog):
             if roles_to_remove:
                 await user.remove_roles(*roles_to_remove, reason=f"New member registration (ran by {message.author.name})", atomic=True)
 
-            if len(rows) != 0:
-                db.cursor.execute(
-                    'UPDATE discord_links SET rank = %s, ign = %s, wars_on_join = %s, uuid = %s, linked = TRUE WHERE discord_id = %s',
-                    (starting_rank, ign, pdata.wars, pdata.UUID, user.id))
+            db = DB()
+            db.connect()
+            try:
+                if len(rows) != 0:
+                    db.cursor.execute(
+                        'UPDATE discord_links SET rank = %s, ign = %s, wars_on_join = %s, uuid = %s, linked = TRUE WHERE discord_id = %s',
+                        (starting_rank, ign, pdata.wars, pdata.UUID, user.id))
+                else:
+                    db.cursor.execute(
+                        'INSERT INTO discord_links (discord_id, ign, uuid, linked, rank, wars_on_join) VALUES (%s, %s, %s, True, %s, %s)',
+                        (user.id, pdata.username, pdata.UUID, starting_rank, pdata.wars))
                 db.connection.commit()
-            else:
-                db.cursor.execute(
-                    'INSERT INTO discord_links (discord_id, ign, uuid, linked, rank, wars_on_join) VALUES (%s, %s, %s, True, %s, %s)',
-                    (user.id, pdata.username, pdata.UUID, starting_rank, pdata.wars))
-                db.connection.commit()
-            db.close()
+            finally:
+                db.close()
             await user.edit(nick=f"{starting_rank} {ign}")
             embed = discord.Embed(title=':white_check_mark: New member registered', description=f'<@{user.id}> was linked to `{pdata.username}`', color=0x3ed63e)
             await message.respond(embed=embed)

--- a/Commands/profile.py
+++ b/Commands/profile.py
@@ -15,7 +15,7 @@ from Helpers.functions import pretty_date, generate_rank_badge, generate_banner,
 from Helpers.logger import log, ERROR
 from Helpers.variables import discord_ranks, minecraft_colors, minecraft_banner_colors
 from Helpers.rate_limiter import external_rate_limit
-from Helpers.storage import get_background, get_cached_avatar, save_cached_avatar
+from Helpers.storage import get_background
 
 
 class Profile(commands.Cog):
@@ -91,19 +91,11 @@ class Profile(commands.Cog):
 
         # Player Avatar
         try:
-            cached = get_cached_avatar(player.UUID)
-            if cached:
-                skin = Image.open(BytesIO(cached))
-            else:
-                headers = {'User-Agent': os.getenv("visage_UA")}
-                url = f"https://visage.surgeplay.com/bust/500/{player.UUID}"
-                response = timed_get(url, headers=headers, timeout=6)
-                response.raise_for_status()
-                try:
-                    save_cached_avatar(player.UUID, response.content)
-                except Exception:
-                    pass
-                skin = Image.open(BytesIO(response.content))
+            headers = {'User-Agent': os.getenv("visage_UA")}
+            url = f"https://visage.surgeplay.com/bust/500/{player.UUID}"
+            response = timed_get(url, headers=headers, timeout=6)
+            response.raise_for_status()
+            skin = Image.open(BytesIO(response.content))
         except Exception as e:
             log(ERROR, f"{e}", context="profile")
             skin = Image.open('images/profile/x-steve500.png')

--- a/Commands/profile.py
+++ b/Commands/profile.py
@@ -18,6 +18,248 @@ from Helpers.rate_limiter import external_rate_limit
 from Helpers.storage import get_background
 
 
+def _build_profile_card(player, days, author_id):
+    """Build the full profile card. Blocking (Pillow + avatar fetch) — always
+    call via asyncio.to_thread so a render never stalls the event loop."""
+    # Check for Christmas (Dec 24-26) and New Year's (Dec 31, Jan 1)
+    today = datetime.now()
+    is_christmas = today.month == 12 and today.day in (24, 25)
+    is_new_years = (today.month == 12 and today.day == 31) or (today.month == 1 and today.day == 1)
+
+    # Base Image + Edge Gradient
+    if is_christmas:
+        card = vertical_gradient(main_color='#c41e3a')  # Christmas red edge
+    elif is_new_years:
+        card = vertical_gradient(main_color='#e11d48')  # New Year's red edge
+    else:
+        card = vertical_gradient(main_color=player.tag_color)
+    card = round_corners(card)
+    draw = ImageDraw.Draw(card)
+
+    # Card Color/Pattern
+    if is_christmas:
+        card_color = vertical_gradient(width=850, height=1130, main_color='#c41e3a', secondary_color='#165b33')  # Red to green
+    elif is_new_years:
+        card_color = vertical_gradient(width=850, height=1130, main_color='#e11d48', secondary_color='#1d4ed8')  # Red to blue
+    elif player.background == 2 and player.gradient == ['#293786', '#1d275e']:    # Set gradient for TAq Sea Turtle BG
+        card_color = vertical_gradient(width=850, height=1130, main_color='#4585db', secondary_color='#2f2b73')
+    else:
+        card_color = vertical_gradient(width=850, height=1130, main_color=player.gradient[0], secondary_color=player.gradient[1])
+
+    card.paste(card_color, (25, 25), card_color)
+
+    # Background Outline
+    if is_christmas:
+        bg_outline = vertical_gradient(width=818, height=545, main_color='#165b33', reverse=True)  # Green outline
+    elif is_new_years:
+        bg_outline = vertical_gradient(width=818, height=545, main_color='#1d4ed8', reverse=True)  # Blue outline
+    else:
+        bg_outline = vertical_gradient(width=818, height=545, main_color=player.tag_color, reverse=True)
+    bg_outline = round_corners(bg_outline)
+    card.paste(bg_outline, (41, 100), bg_outline)
+
+    # Background
+    if is_christmas:
+        background = get_background("christmas_background")
+    elif is_new_years:
+        background = get_background("new_years_background")
+    else:
+        background = get_background(player.background)
+    background = round_corners(background, radius=20)
+    card.paste(background, (50, 110), background)
+
+    # Player Name
+    name_font = ImageFont.truetype('images/profile/game.ttf', 50)
+    addLine(text=player.username, draw=draw, font=name_font, x=50, y=40, drop_x=7, drop_y=7)
+
+    # Player Avatar
+    try:
+        headers = {'User-Agent': os.getenv("visage_UA")}
+        url = f"https://visage.surgeplay.com/bust/500/{player.UUID}"
+        response = timed_get(url, headers=headers, timeout=6)
+        response.raise_for_status()
+        skin = Image.open(BytesIO(response.content))
+    except Exception as e:
+        log(ERROR, f"{e}", context="profile")
+        skin = Image.open('images/profile/x-steve500.png')
+    skin.thumbnail((480, 480))
+    card.paste(skin, (200, 156), skin)
+
+    # Wynn Rank Badge
+    rank = generate_rank_badge(player.tag_display, player.tag_color)
+    rank_w, rank_h = rank.size
+    card.paste(rank, (450 - int(rank_w / 2), 96), rank)
+
+    # Guild Related
+    if player.guild:
+        # Get Guild Color
+        try:
+            guild_banner = player.guild_data['banner'] if player.guild_data else getData(player.guild)['banner']
+            if guild_banner['base'] in ['BLACK', 'GRAY', 'BROWN']:
+                for layer in guild_banner['layers']:
+                    if layer['colour'] not in ['BLACK', 'GRAY', 'BROWN']:
+                        guild_colour = layer['colour']
+                        break
+                    else:
+                        guild_colour = "WHITE"
+            else:
+                guild_colour = guild_banner['base']
+        except:
+            guild_colour = "WHITE"
+
+        rank_row_y = 663
+
+        # Guild Name Badge
+        guild_badge = generate_badge(text=player.guild, base_color='#{:02x}{:02x}{:02x}'.format(*minecraft_banner_colors[guild_colour]), scale=3)
+        guild_badge.crop(guild_badge.getbbox())
+        card.paste(guild_badge, (108, 615), guild_badge)
+
+        # Guild Rank Badge Generation
+        if player.taq and player.linked:
+            try:
+                guild_rank_badge = generate_badge(text=player.rank.upper(), base_color=discord_ranks[player.rank]['color'], scale=3)
+            except:
+                guild_rank_badge = generate_badge(text=player.guild_rank.upper(), base_color='#a0aeb0', scale=3)
+        else:
+            guild_rank_badge = generate_badge(text=player.guild_rank.upper(), base_color='#a0aeb0', scale=3)
+        guild_rank_badge.crop(guild_rank_badge.getbbox())
+
+        # Membership Time Badge Generation
+        member_for_badge = generate_badge(text=f'{player.in_guild_for.days} D', base_color='#363636', scale=3)
+        member_for_badge.crop(member_for_badge.getbbox())
+
+        # Insert Membership & Rank Badges
+        grb_w = guild_rank_badge.width
+        card.paste(member_for_badge, (90 + grb_w, rank_row_y), member_for_badge)
+        card.paste(guild_rank_badge, (108, rank_row_y), guild_rank_badge)
+
+        # Guild Banner
+        banner = generate_banner(player.guild, 15, "2", guild_data=player.guild_data)
+        banner.thumbnail((157, 157))
+        card.paste(banner, (41, 558))
+
+    # Build out data to place in boxes
+    card_entries = {}
+    try:
+        if player.online:
+            card_entries['World'] = player.server
+        else:
+            # Last Seen - check if private
+            if player.last_joined_is_private:
+                card_entries['Last Seen'] = '&cPrivate'
+            else:
+                card_entries['Last Seen'] = pretty_date(player.last_joined)
+
+        # Total Level - check if private
+        if player.total_level_is_private:
+            card_entries['Total Level'] = '&cPrivate'
+        else:
+            card_entries['Total Level'] = f'{player.total_level}'
+
+        # Playtime - check if private
+        if player.playtime_is_private:
+            card_entries['Playtime'] = '&cPrivate'
+        else:
+            card_entries['Playtime'] = f'{int(player.playtime)} hrs'
+
+        if player.taq and player.in_guild_for.days >= 1:
+            # Timed playtime - check if private
+            if player.real_pt_is_private:
+                card_entries[f'Playtime / {player.stats_days} D'] = '&cPrivate'
+            else:
+                card_entries[f'Playtime / {player.stats_days} D'] = f'{int(player.real_pt)} hrs'
+
+        # Wars - check if private
+        if player.wars_is_private:
+            card_entries['Wars'] = '&cPrivate'
+        else:
+            card_entries['Wars'] = str(player.wars)
+
+        if player.taq and player.in_guild_for.days >= 1:
+            # Timed wars - check if private
+            if player.real_wars_is_private:
+                card_entries[f'Wars / {player.stats_days} D'] = '&cPrivate'
+            else:
+                card_entries[f'Wars / {player.stats_days} D'] = str(player.real_wars)
+
+        if player.guild:
+            # Guild XP - check if private
+            if player.guild_contributed_is_private:
+                card_entries['Guild XP'] = '&cPrivate'
+            else:
+                card_entries['Guild XP'] = format_number(player.guild_contributed)
+
+        if player.taq and player.in_guild_for.days >= 1:
+            # Timed Guild XP - check if private
+            if player.real_xp_is_private:
+                card_entries[f'Guild XP / {player.stats_days} D'] = '&cPrivate'
+            else:
+                card_entries[f'Guild XP / {player.stats_days} D'] = format_number(player.real_xp)
+
+        if player.taq:
+            card_entries['Guild Raids'] = str(player.guild_raids)
+            if player.in_guild_for.days >= 1:
+                # Timed raids - check if private
+                if player.real_raids_is_private:
+                    card_entries[f'Guild Raids / {player.stats_days} D'] = '&cPrivate'
+                else:
+                    card_entries[f'Guild Raids / {player.stats_days} D'] = str(player.real_raids)
+
+        # if len(card_entries) < 10:
+        #     card_entries['Killed Mobs'] = str(player.mobs)
+        if len(card_entries) < 10:
+            # Chests - check if private
+            if player.chests_is_private:
+                card_entries['Chests Looted'] = '&cPrivate'
+            else:
+                card_entries['Chests Looted'] = str(player.chests)
+
+        if len(card_entries) < 10:
+            # Quests - check if private
+            if player.quests_is_private:
+                card_entries['Quests'] = '&cPrivate'
+            else:
+                card_entries['Quests'] = str(player.quests)
+    except Exception as e:
+        log(ERROR, f"{e}", context="profile")
+
+    entry_keys = list(card_entries.keys())
+
+    title_font = ImageFont.truetype('images/profile/5x5.ttf', 40)
+    data_font = ImageFont.truetype('images/profile/game.ttf', 35)
+    box = Image.new('RGBA', (390, 75), (0, 0, 0, 0))
+    box_draw = ImageDraw.Draw(box)
+    box_draw.rounded_rectangle(((0, 0), (390, 75)), fill=(0, 0, 0, 30), radius=10)
+
+    for entry in range(len(card_entries)):
+        card.paste(box, (50 + ((entry % 2) * 410), 730 + (int(entry / 2) * 85)), box)
+        draw.text((60 + ((entry % 2) * 410), 720 + (int(entry / 2) * 85)), text=entry_keys[entry], font=title_font, fill='#fad51e')
+        # Use addLine to support color codes like &c for red "Private" text
+        addLine(text=card_entries[entry_keys[entry]], draw=draw, font=data_font, x=430 + ((entry % 2) * 410), y=765 + (int(entry / 2) * 85), anchor="ra")
+
+    if player.linked:
+        # Shells
+        data_font = ImageFont.truetype('images/profile/game.ttf', 50)
+        shells_img = Image.open('images/profile/shells.png')
+        shells_img.thumbnail((50, 50))
+        addLine(text=str(player.balance), draw=draw, font=data_font, x=781, y=46, drop_x=7, drop_y=7, anchor="rt")
+        card.paste(shells_img, (800, 40), shells_img)
+
+        if player.guild and player.taq:
+            if str(author_id) == str(player.discord) and player.in_guild_for.days >= 365 and 3 not in player.backgrounds_owned:
+                player.unlock_background('1 Year Anniversary')
+            if str(author_id) == str(player.discord) and player.rank.upper() in ['NARWHAL', 'HYDRA'] and 2 not in player.backgrounds_owned:
+                player.unlock_background('TAq Sea Turtle')
+
+    with BytesIO() as file:
+        card.save(file, format="PNG")
+        file.seek(0)
+        t = int(time.time())
+        profile_card = discord.File(file, filename=f"profile{t}.png")
+
+    return profile_card
+
+
 class Profile(commands.Cog):
     def __init__(self, client):
         self.client = client
@@ -38,242 +280,7 @@ class Profile(commands.Cog):
             await ctx.followup.send(embed=embed, ephemeral=True)
             return
 
-        # Check for Christmas (Dec 24-26) and New Year's (Dec 31, Jan 1)
-        today = datetime.now()
-        is_christmas = today.month == 12 and today.day in (24, 25)
-        is_new_years = (today.month == 12 and today.day == 31) or (today.month == 1 and today.day == 1)
-
-        # Base Image + Edge Gradient
-        if is_christmas:
-            card = vertical_gradient(main_color='#c41e3a')  # Christmas red edge
-        elif is_new_years:
-            card = vertical_gradient(main_color='#e11d48')  # New Year's red edge
-        else:
-            card = vertical_gradient(main_color=player.tag_color)
-        card = round_corners(card)
-        draw = ImageDraw.Draw(card)
-
-        # Card Color/Pattern
-        if is_christmas:
-            card_color = vertical_gradient(width=850, height=1130, main_color='#c41e3a', secondary_color='#165b33')  # Red to green
-        elif is_new_years:
-            card_color = vertical_gradient(width=850, height=1130, main_color='#e11d48', secondary_color='#1d4ed8')  # Red to blue
-        elif player.background == 2 and player.gradient == ['#293786', '#1d275e']:    # Set gradient for TAq Sea Turtle BG
-            card_color = vertical_gradient(width=850, height=1130, main_color='#4585db', secondary_color='#2f2b73')
-        else:
-            card_color = vertical_gradient(width=850, height=1130, main_color=player.gradient[0], secondary_color=player.gradient[1])
-
-        card.paste(card_color, (25, 25), card_color)
-
-        # Background Outline
-        if is_christmas:
-            bg_outline = vertical_gradient(width=818, height=545, main_color='#165b33', reverse=True)  # Green outline
-        elif is_new_years:
-            bg_outline = vertical_gradient(width=818, height=545, main_color='#1d4ed8', reverse=True)  # Blue outline
-        else:
-            bg_outline = vertical_gradient(width=818, height=545, main_color=player.tag_color, reverse=True)
-        bg_outline = round_corners(bg_outline)
-        card.paste(bg_outline, (41, 100), bg_outline)
-
-        # Background
-        if is_christmas:
-            background = get_background("christmas_background")
-        elif is_new_years:
-            background = get_background("new_years_background")
-        else:
-            background = get_background(player.background)
-        background = round_corners(background, radius=20)
-        card.paste(background, (50, 110), background)
-
-        # Player Name
-        name_font = ImageFont.truetype('images/profile/game.ttf', 50)
-        addLine(text=player.username, draw=draw, font=name_font, x=50, y=40, drop_x=7, drop_y=7)
-
-        # Player Avatar
-        try:
-            headers = {'User-Agent': os.getenv("visage_UA")}
-            url = f"https://visage.surgeplay.com/bust/500/{player.UUID}"
-            response = timed_get(url, headers=headers, timeout=6)
-            response.raise_for_status()
-            skin = Image.open(BytesIO(response.content))
-        except Exception as e:
-            log(ERROR, f"{e}", context="profile")
-            skin = Image.open('images/profile/x-steve500.png')
-        skin.thumbnail((480, 480))
-        card.paste(skin, (200, 156), skin)
-
-        # Wynn Rank Badge
-        rank = generate_rank_badge(player.tag_display, player.tag_color)
-        rank_w, rank_h = rank.size
-        card.paste(rank, (450 - int(rank_w / 2), 96), rank)
-
-        # Guild Related
-        if player.guild:
-            # Get Guild Color
-            try:
-                guild_banner = player.guild_data['banner'] if player.guild_data else getData(player.guild)['banner']
-                if guild_banner['base'] in ['BLACK', 'GRAY', 'BROWN']:
-                    for layer in guild_banner['layers']:
-                        if layer['colour'] not in ['BLACK', 'GRAY', 'BROWN']:
-                            guild_colour = layer['colour']
-                            break
-                        else:
-                            guild_colour = "WHITE"
-                else:
-                    guild_colour = guild_banner['base']
-            except:
-                guild_colour = "WHITE"
-
-            rank_row_y = 663
-
-            # Guild Name Badge
-            guild_badge = generate_badge(text=player.guild, base_color='#{:02x}{:02x}{:02x}'.format(*minecraft_banner_colors[guild_colour]), scale=3)
-            guild_badge.crop(guild_badge.getbbox())
-            card.paste(guild_badge, (108, 615), guild_badge)
-
-            # Guild Rank Badge Generation
-            if player.taq and player.linked:
-                try:
-                    guild_rank_badge = generate_badge(text=player.rank.upper(), base_color=discord_ranks[player.rank]['color'], scale=3)
-                except:
-                    guild_rank_badge = generate_badge(text=player.guild_rank.upper(), base_color='#a0aeb0', scale=3)
-            else:
-                guild_rank_badge = generate_badge(text=player.guild_rank.upper(), base_color='#a0aeb0', scale=3)
-            guild_rank_badge.crop(guild_rank_badge.getbbox())
-
-            # Membership Time Badge Generation
-            member_for_badge = generate_badge(text=f'{player.in_guild_for.days} D', base_color='#363636', scale=3)
-            member_for_badge.crop(member_for_badge.getbbox())
-
-            # Insert Membership & Rank Badges
-            grb_w = guild_rank_badge.width
-            card.paste(member_for_badge, (90 + grb_w, rank_row_y), member_for_badge)
-            card.paste(guild_rank_badge, (108, rank_row_y), guild_rank_badge)
-
-            # Guild Banner
-            banner = generate_banner(player.guild, 15, "2", guild_data=player.guild_data)
-            banner.thumbnail((157, 157))
-            card.paste(banner, (41, 558))
-
-        # Build out data to place in boxes
-        card_entries = {}
-        try:
-            if player.online:
-                card_entries['World'] = player.server
-            else:
-                # Last Seen - check if private
-                if player.last_joined_is_private:
-                    card_entries['Last Seen'] = '&cPrivate'
-                else:
-                    card_entries['Last Seen'] = pretty_date(player.last_joined)
-
-            # Total Level - check if private
-            if player.total_level_is_private:
-                card_entries['Total Level'] = '&cPrivate'
-            else:
-                card_entries['Total Level'] = f'{player.total_level}'
-
-            # Playtime - check if private
-            if player.playtime_is_private:
-                card_entries['Playtime'] = '&cPrivate'
-            else:
-                card_entries['Playtime'] = f'{int(player.playtime)} hrs'
-
-            if player.taq and player.in_guild_for.days >= 1:
-                # Timed playtime - check if private
-                if player.real_pt_is_private:
-                    card_entries[f'Playtime / {player.stats_days} D'] = '&cPrivate'
-                else:
-                    card_entries[f'Playtime / {player.stats_days} D'] = f'{int(player.real_pt)} hrs'
-
-            # Wars - check if private
-            if player.wars_is_private:
-                card_entries['Wars'] = '&cPrivate'
-            else:
-                card_entries['Wars'] = str(player.wars)
-
-            if player.taq and player.in_guild_for.days >= 1:
-                # Timed wars - check if private
-                if player.real_wars_is_private:
-                    card_entries[f'Wars / {player.stats_days} D'] = '&cPrivate'
-                else:
-                    card_entries[f'Wars / {player.stats_days} D'] = str(player.real_wars)
-
-            if player.guild:
-                # Guild XP - check if private
-                if player.guild_contributed_is_private:
-                    card_entries['Guild XP'] = '&cPrivate'
-                else:
-                    card_entries['Guild XP'] = format_number(player.guild_contributed)
-
-            if player.taq and player.in_guild_for.days >= 1:
-                # Timed Guild XP - check if private
-                if player.real_xp_is_private:
-                    card_entries[f'Guild XP / {player.stats_days} D'] = '&cPrivate'
-                else:
-                    card_entries[f'Guild XP / {player.stats_days} D'] = format_number(player.real_xp)
-
-            if player.taq:
-                card_entries['Guild Raids'] = str(player.guild_raids)
-                if player.in_guild_for.days >= 1:
-                    # Timed raids - check if private
-                    if player.real_raids_is_private:
-                        card_entries[f'Guild Raids / {player.stats_days} D'] = '&cPrivate'
-                    else:
-                        card_entries[f'Guild Raids / {player.stats_days} D'] = str(player.real_raids)
-
-            # if len(card_entries) < 10:
-            #     card_entries['Killed Mobs'] = str(player.mobs)
-            if len(card_entries) < 10:
-                # Chests - check if private
-                if player.chests_is_private:
-                    card_entries['Chests Looted'] = '&cPrivate'
-                else:
-                    card_entries['Chests Looted'] = str(player.chests)
-
-            if len(card_entries) < 10:
-                # Quests - check if private
-                if player.quests_is_private:
-                    card_entries['Quests'] = '&cPrivate'
-                else:
-                    card_entries['Quests'] = str(player.quests)
-        except Exception as e:
-            log(ERROR, f"{e}", context="profile")
-
-        entry_keys = list(card_entries.keys())
-
-        title_font = ImageFont.truetype('images/profile/5x5.ttf', 40)
-        data_font = ImageFont.truetype('images/profile/game.ttf', 35)
-        box = Image.new('RGBA', (390, 75), (0, 0, 0, 0))
-        box_draw = ImageDraw.Draw(box)
-        box_draw.rounded_rectangle(((0, 0), (390, 75)), fill=(0, 0, 0, 30), radius=10)
-
-        for entry in range(len(card_entries)):
-            card.paste(box, (50 + ((entry % 2) * 410), 730 + (int(entry / 2) * 85)), box)
-            draw.text((60 + ((entry % 2) * 410), 720 + (int(entry / 2) * 85)), text=entry_keys[entry], font=title_font, fill='#fad51e')
-            # Use addLine to support color codes like &c for red "Private" text
-            addLine(text=card_entries[entry_keys[entry]], draw=draw, font=data_font, x=430 + ((entry % 2) * 410), y=765 + (int(entry / 2) * 85), anchor="ra")
-
-        if player.linked:
-            # Shells
-            data_font = ImageFont.truetype('images/profile/game.ttf', 50)
-            shells_img = Image.open('images/profile/shells.png')
-            shells_img.thumbnail((50, 50))
-            addLine(text=str(player.balance), draw=draw, font=data_font, x=781, y=46, drop_x=7, drop_y=7, anchor="rt")
-            card.paste(shells_img, (800, 40), shells_img)
-
-            if player.guild and player.taq:
-                if str(ctx.author.id) == str(player.discord) and player.in_guild_for.days >= 365 and 3 not in player.backgrounds_owned:
-                    player.unlock_background('1 Year Anniversary')
-                if str(ctx.author.id) == str(player.discord) and player.rank.upper() in ['NARWHAL', 'HYDRA'] and 2 not in player.backgrounds_owned:
-                    player.unlock_background('TAq Sea Turtle')
-
-        with BytesIO() as file:
-            card.save(file, format="PNG")
-            file.seek(0)
-            t = int(time.time())
-            profile_card = discord.File(file, filename=f"profile{t}.png")
-
+        profile_card = await asyncio.to_thread(_build_profile_card, player, days, ctx.author.id)
         await ctx.followup.send(file=profile_card)
 
     @commands.Cog.listener()

--- a/Commands/progress.py
+++ b/Commands/progress.py
@@ -4,14 +4,13 @@ import time
 from io import BytesIO
 
 import discord
-import requests
 from PIL import Image, ImageFont, ImageDraw
 from discord.ext import commands
 from discord.commands import slash_command
 from discord.ui import Select, View
 
 from Helpers.classes import PlayerStats
-from Helpers.functions import getPlayerData, fix_progressbar, getPlayerUUID, generate_rank_badge, create_progress_bar
+from Helpers.functions import getPlayerData, fix_progressbar, getPlayerUUID, generate_rank_badge, create_progress_bar, timed_get
 from Helpers.variables import class_map
 from Helpers.rate_limiter import external_rate_limit
 from Helpers.logger import log, ERROR
@@ -79,7 +78,7 @@ class Progress(commands.Cog):
             try:
                 headers = {'User-Agent': os.getenv("visage_UA")}
                 url = f"https://visage.surgeplay.com/bust/500/{playerdata.UUID}"
-                response = requests.get(url, headers=headers, timeout=6)
+                response = timed_get(url, headers=headers, timeout=6)
                 skin = Image.open(BytesIO(response.content))
             except Exception as e:
                 log(ERROR, f"{e}", context="progress")

--- a/Commands/raids.py
+++ b/Commands/raids.py
@@ -158,7 +158,7 @@ class Raids(commands.Cog):
         safe_name = quote(name)
         url = f"https://api.wynncraft.com/v3/player/{safe_name}"
         try:
-            res = requests.get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
+            res = timed_get(url, timeout=10, headers={"Authorization": f"Bearer {os.getenv('WYNN_TOKEN')}"})
         except requests.RequestException:
             return None
         if res.status_code != 200:

--- a/Commands/raids.py
+++ b/Commands/raids.py
@@ -19,11 +19,12 @@ from Helpers.functions import (
     generate_banner,
     getData,
     generate_badge,
+    timed_get,
 )
 from Helpers.classes import PlayerStats
 from Helpers.variables import discord_ranks, minecraft_banner_colors
 from Helpers.rate_limiter import external_rate_limit
-from Helpers.storage import get_background, get_cached_avatar, save_cached_avatar
+from Helpers.storage import get_background
 
 # ---------------------------------------------------------------------------
 # Raids Command
@@ -299,19 +300,11 @@ class Raids(commands.Cog):
             if not uuid:
                 raise ValueError("Missing player UUID")
 
-            cached = get_cached_avatar(uuid)
-            if cached:
-                skin = Image.open(BytesIO(cached)).convert('RGBA')
-            else:
-                headers = {'User-Agent': os.getenv("visage_UA", "")}
-                av_url = f"https://visage.surgeplay.com/bust/500/{uuid}"
-                resp = requests.get(av_url, headers=headers, timeout=6)
-                resp.raise_for_status()
-                try:
-                    save_cached_avatar(uuid, resp.content)
-                except Exception:
-                    pass
-                skin = Image.open(BytesIO(resp.content)).convert('RGBA')
+            headers = {'User-Agent': os.getenv("visage_UA", "")}
+            av_url = f"https://visage.surgeplay.com/bust/500/{uuid}"
+            resp = timed_get(av_url, headers=headers, timeout=6)
+            resp.raise_for_status()
+            skin = Image.open(BytesIO(resp.content)).convert('RGBA')
         except Exception:
             skin = Image.open('images/profile/x-steve500.png').convert('RGBA')
         skin.thumbnail((480, 480))

--- a/Commands/snipe.py
+++ b/Commands/snipe.py
@@ -15,7 +15,7 @@ from PIL import Image, ImageDraw, ImageFont
 
 from Helpers.classes import Guild, Page, PlayerStats
 from Helpers.database import DB, get_current_guild_data
-from Helpers.functions import addLine, generate_badge, get_guild_color, vertical_gradient, round_corners
+from Helpers.functions import addLine, generate_badge, get_guild_color, vertical_gradient, round_corners, timed_get
 from Helpers.snipe_utils import ALL_TERRITORY_NAMES, display_hq, is_dry, normalize_hq_for_storage
 from Helpers.variables import ALL_GUILD_IDS, HQ_TEAM_ROLE_ID, TAQ_GUILD_ID, SNIPE_LOG_CHANNEL_ID, discord_ranks
 
@@ -401,7 +401,7 @@ def _load_athena_guild_colors_sync() -> dict[str, str]:
         return _ATHENA_GUILD_COLORS
 
     try:
-        response = requests.get(_ATHENA_GUILD_LIST_URL, timeout=15)
+        response = timed_get(_ATHENA_GUILD_LIST_URL, timeout=15)
         response.raise_for_status()
         payload = response.json()
         colors = {}

--- a/Commands/snipe.py
+++ b/Commands/snipe.py
@@ -15,6 +15,7 @@ from PIL import Image, ImageDraw, ImageFont
 from Helpers.classes import Guild, Page, PlayerStats
 from Helpers.database import DB, get_current_guild_data
 from Helpers.functions import addLine, generate_badge, get_guild_color, vertical_gradient, round_corners, timed_get
+from Helpers.logger import log, ERROR
 from Helpers.snipe_utils import ALL_TERRITORY_NAMES, display_hq, is_dry, normalize_hq_for_storage
 from Helpers.variables import ALL_GUILD_IDS, HQ_TEAM_ROLE_ID, TAQ_GUILD_ID, SNIPE_LOG_CHANNEL_ID, discord_ranks
 
@@ -1285,11 +1286,17 @@ class SnipeTracker(commands.Cog):
                 f"**Result:** Success"
                 + (f"\n**Notes:** {notes}" if notes else "")
             )
-            resp     = await asyncio.to_thread(timed_get, image.url)
-            img_file = discord.File(BytesIO(resp.content), filename=image.filename)
-            channel  = ctx.bot.get_channel(SNIPE_LOG_CHANNEL_ID)
+            channel = ctx.bot.get_channel(SNIPE_LOG_CHANNEL_ID)
             if channel:
-                await channel.send(content=log_text, file=img_file)
+                # The snipe is already recorded and the user already saw the
+                # success embed; a failed image fetch must not error the command.
+                try:
+                    resp = await asyncio.to_thread(timed_get, image.url)
+                    img_file = discord.File(BytesIO(resp.content), filename=image.filename)
+                    await channel.send(content=log_text, file=img_file)
+                except Exception as e:
+                    log(ERROR, f"Snipe log image fetch failed, posting without image: {e}", context="snipe")
+                    await channel.send(content=log_text)
 
     # ── /snipe stats ──────────────────────────────────────────────────────────
 

--- a/Commands/snipe.py
+++ b/Commands/snipe.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta, timezone
 from io import BytesIO
 
 import discord
-import requests
 from discord.ext import commands, pages
 from discord.commands import SlashCommandGroup, slash_command
 from PIL import Image, ImageDraw, ImageFont
@@ -1286,7 +1285,7 @@ class SnipeTracker(commands.Cog):
                 f"**Result:** Success"
                 + (f"\n**Notes:** {notes}" if notes else "")
             )
-            resp     = await asyncio.to_thread(requests.get, image.url)
+            resp     = await asyncio.to_thread(timed_get, image.url)
             img_file = discord.File(BytesIO(resp.content), filename=image.filename)
             channel  = ctx.bot.get_channel(SNIPE_LOG_CHANNEL_ID)
             if channel:

--- a/Commands/worlds.py
+++ b/Commands/worlds.py
@@ -5,11 +5,11 @@ from discord.ext import commands
 from discord.commands import slash_command
 from discord.ext import pages
 import json
-import requests
 import time
 import datetime
 import math
 
+from Helpers.functions import timed_get
 from Helpers.rate_limiter import external_rate_limit
 from Helpers.pagination import add_paginator_buttons
 
@@ -31,7 +31,7 @@ class Worlds(commands.Cog):
         await message.defer()
         url = 'https://athena.wynntils.com/cache/get/serverList'
 
-        data = await asyncio.to_thread(requests.get, url, timeout=10)
+        data = await asyncio.to_thread(timed_get, url, timeout=10)
         data.raise_for_status()
         worlds = data.json()
         

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -67,7 +67,6 @@ class Guild:
 class PlayerStats:
     def __init__(self, name, days, load_timed_stats=True):
         db = DB()
-        db.connect()
         try:
             pdata = self._load_player_payload(name)
             if self.error:
@@ -76,6 +75,7 @@ class PlayerStats:
             self.player_data = pdata
             self._load_player_fields(pdata)
             self._load_guild_fields(pdata)
+            db.connect()
             self._load_profile_db_state(db)
             if load_timed_stats:
                 self._load_timed_stats(db, days)

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -407,6 +407,11 @@ class BasicPlayerStats:
 
         # player data
         pdata = getPlayerDatav3(self.UUID)
+        if not pdata:
+            # getPlayerDatav3 returns False on failure; without this guard the
+            # attribute reads below raise AttributeError instead of error=True.
+            self.error = True
+            return
         self.rank = pdata.get('rank', 'Player')
         if self.rank == 'Player':
             support_rank = pdata.get('supportRank')

--- a/Helpers/database.py
+++ b/Helpers/database.py
@@ -2,10 +2,12 @@ import datetime
 from datetime import timedelta
 import json
 import os
+import threading
 import time
 
 import psycopg2
 from psycopg2 import OperationalError
+from psycopg2 import pool as _pg_pool
 
 from Helpers import telemetry
 from Helpers.logger import log, ERROR
@@ -62,6 +64,58 @@ class _TimedConnection:
         setattr(self.__dict__["_connection"], name, value)
 
 
+# Process-wide connection pool. One pool per process, created lazily on first
+# checkout; DB.connect()/DB.close() become checkout/return so all existing
+# helpers and call sites get pooling without change. Phase 0 measured a fresh
+# connect at 120-674ms per command; a warm checkout is sub-millisecond.
+_pool = None
+_pool_lock = threading.Lock()
+
+
+def _connection_kwargs():
+    if os.getenv("TEST_MODE").lower() == "true":
+        prefix, default_db = "TEST_DB", "postgres"
+    elif os.getenv("TEST_MODE").lower() == "false":
+        prefix, default_db = "DB", "postgres"
+    else:
+        log(ERROR, "Problem logging into db", context="database")
+        exit(-1)
+    return dict(
+        user=os.getenv(f"{prefix}_LOGIN"),
+        password=os.getenv(f"{prefix}_PASS"),
+        host=os.getenv(f"{prefix}_HOST"),
+        port=int(os.getenv(f"{prefix}_PORT")),
+        database=os.getenv(f"{prefix}_DATABASE", default_db),
+        sslmode=os.getenv(f"{prefix}_SSLMODE"),
+        keepalives=1,
+        keepalives_idle=30,
+        keepalives_interval=10,
+        keepalives_count=5,
+    )
+
+
+def _get_pool():
+    global _pool
+    if _pool is None:
+        with _pool_lock:
+            if _pool is None:
+                _pool = _pg_pool.ThreadedConnectionPool(
+                    1, int(os.getenv("DB_POOL_MAX", "8")), **_connection_kwargs()
+                )
+    return _pool
+
+
+def _reset_pool_for_tests():
+    """Drop the pool singleton. Test hook only."""
+    global _pool
+    if _pool is not None:
+        try:
+            _pool.closeall()
+        except Exception:
+            pass
+    _pool = None
+
+
 class DB:
     def __init__(self):
         self.connection = None
@@ -69,41 +123,10 @@ class DB:
 
     def connect(self):
         try:
-            if os.getenv("TEST_MODE").lower() == "true":
-                with telemetry.track("db.connect"):
-                    raw_connection = psycopg2.connect(
-                        user=os.getenv("TEST_DB_LOGIN"),
-                        password=os.getenv("TEST_DB_PASS"),
-                        host=os.getenv("TEST_DB_HOST"),
-                        port=int(os.getenv("TEST_DB_PORT")),
-                        database=os.getenv("TEST_DB_DATABASE", "postgres"),
-                        sslmode=os.getenv("TEST_DB_SSLMODE"),
-                        keepalives=1,
-                        keepalives_idle=30,
-                        keepalives_interval=10,
-                        keepalives_count=5
-                    )
-                self.connection = _TimedConnection(raw_connection)
-                self.cursor = _TimedCursor(raw_connection.cursor())
-            elif os.getenv("TEST_MODE").lower() == "false":
-                with telemetry.track("db.connect"):
-                    raw_connection = psycopg2.connect(
-                        user=os.getenv("DB_LOGIN"),
-                        password=os.getenv("DB_PASS"),
-                        host=os.getenv("DB_HOST"),
-                        port=int(os.getenv("DB_PORT")),
-                        database=os.getenv("DB_DATABASE", "postgres"),
-                        sslmode=os.getenv("DB_SSLMODE"),
-                        keepalives=1,
-                        keepalives_idle=30,
-                        keepalives_interval=10,
-                        keepalives_count=5
-                    )
-                self.connection = _TimedConnection(raw_connection)
-                self.cursor = _TimedCursor(raw_connection.cursor())
-            else:
-                log(ERROR, "Problem logging into db", context="database")
-                exit(-1)
+            with telemetry.track("db.connect"):
+                raw_connection = _get_pool().getconn()
+            self.connection = _TimedConnection(raw_connection)
+            self.cursor = _TimedCursor(raw_connection.cursor())
         except OperationalError as e:
             log(ERROR, f"Connection failed: {e}", context="database")
             raise
@@ -116,11 +139,27 @@ class DB:
         self.close()
 
     def close(self):
-        """Close cursor and connection."""
+        """Return the connection to the pool (rolled back), discarding broken ones."""
         if self.cursor:
-            self.cursor.close()
+            try:
+                self.cursor.close()
+            except Exception:
+                pass
         if self.connection:
-            self.connection.close()
+            raw = self.connection.__dict__["_connection"]
+            try:
+                if raw.closed:
+                    _get_pool().putconn(raw, close=True)
+                else:
+                    raw.rollback()
+                    _get_pool().putconn(raw)
+            except Exception:
+                try:
+                    _get_pool().putconn(raw, close=True)
+                except Exception:
+                    pass
+        self.connection = None
+        self.cursor = None
 
 
 class BatchBaselineQueryError(RuntimeError):

--- a/Helpers/database.py
+++ b/Helpers/database.py
@@ -9,7 +9,7 @@ from psycopg2 import OperationalError
 from psycopg2 import pool as _pg_pool
 
 from Helpers import telemetry
-from Helpers.logger import log, ERROR
+from Helpers.logger import log, ERROR, WARN
 
 
 class _TimedCursor:
@@ -132,6 +132,7 @@ class DB:
                     except _pg_pool.PoolError:
                         if attempt >= len(retry_delays):
                             raise
+                        log(WARN, f"DB pool exhausted, retrying (attempt {attempt + 1})", context="database")
                         time.sleep(retry_delays[attempt])
                         attempt += 1
             try:

--- a/Helpers/database.py
+++ b/Helpers/database.py
@@ -5,7 +5,6 @@ import os
 import threading
 import time
 
-import psycopg2
 from psycopg2 import OperationalError
 from psycopg2 import pool as _pg_pool
 
@@ -125,9 +124,16 @@ class DB:
         try:
             with telemetry.track("db.connect"):
                 raw_connection = _get_pool().getconn()
-            self.connection = _TimedConnection(raw_connection)
-            self.cursor = _TimedCursor(raw_connection.cursor())
-        except OperationalError as e:
+            try:
+                self.connection = _TimedConnection(raw_connection)
+                self.cursor = _TimedCursor(raw_connection.cursor())
+            except Exception:
+                try:
+                    _get_pool().putconn(raw_connection, close=True)
+                except Exception:
+                    pass
+                raise
+        except (OperationalError, _pg_pool.PoolError) as e:
             log(ERROR, f"Connection failed: {e}", context="database")
             raise
 

--- a/Helpers/database.py
+++ b/Helpers/database.py
@@ -123,7 +123,17 @@ class DB:
     def connect(self):
         try:
             with telemetry.track("db.connect"):
-                raw_connection = _get_pool().getconn()
+                retry_delays = (0.2, 0.4)
+                attempt = 0
+                while True:
+                    try:
+                        raw_connection = _get_pool().getconn()
+                        break
+                    except _pg_pool.PoolError:
+                        if attempt >= len(retry_delays):
+                            raise
+                        time.sleep(retry_delays[attempt])
+                        attempt += 1
             try:
                 self.connection = _TimedConnection(raw_connection)
                 self.cursor = _TimedCursor(raw_connection.cursor())

--- a/Helpers/functions.py
+++ b/Helpers/functions.py
@@ -5,6 +5,7 @@ import os
 import json
 import re
 from functools import lru_cache
+from http import cookiejar as _cookiejar
 from io import BytesIO
 from urllib.parse import quote, urlparse
 from uuid import UUID
@@ -28,6 +29,22 @@ def _cached_font(path, size):
 # request execution is thread-safe; pool sized for concurrent commands + tasks.
 _session = requests.Session()
 _session.mount("https://", requests.adapters.HTTPAdapter(pool_connections=16, pool_maxsize=16))
+
+
+class _BlockAllCookies(_cookiejar.CookiePolicy):
+    """Cookie policy: never store or send cookies.
+
+    The shared session is used concurrently by three distinct token
+    identities; a shared cookie jar (e.g. Cloudflare's __cf_bm from
+    api.wynncraft.com) would leak state between them, and jar writes
+    aren't thread-safe. Keeping the session stateless sidesteps both.
+    """
+    return_ok = set_ok = domain_return_ok = path_return_ok = lambda self, *args, **kwargs: False
+    netscape = True
+    rfc2965 = hide_cookie2 = False
+
+
+_session.cookies.set_policy(_BlockAllCookies())
 
 
 def timed_get(url, **kwargs):

--- a/Helpers/functions.py
+++ b/Helpers/functions.py
@@ -23,18 +23,21 @@ def _cached_font(path, size):
     return ImageFont.truetype(path, size)
 
 
-def timed_get(url, **kwargs):
-    """requests.get with per-host timing.
+# Shared session: keep-alive across all outbound GETs. Phase 0 measured fresh
+# TLS per call at 250-460ms/request; reuse cuts that to ~70-140ms. Session
+# request execution is thread-safe; pool sized for concurrent commands + tasks.
+_session = requests.Session()
+_session.mount("https://", requests.adapters.HTTPAdapter(pool_connections=16, pool_maxsize=16))
 
-    Deliberately does NOT reuse a Session. Phase 0 must not change behaviour, and
-    session reuse is a Phase 1 fix whose benefit is measured against these numbers.
-    """
+
+def timed_get(url, **kwargs):
+    """GET with per-host timing, through the shared keep-alive session."""
     try:
         host = urlparse(url).hostname or "unknown"
     except Exception:
         host = "unknown"
     with telemetry.track(f"http.{host}"):
-        return requests.get(url, **kwargs)
+        return _session.get(url, **kwargs)
 
 
 def isInCurrDay(data, uuid):

--- a/Helpers/functions.py
+++ b/Helpers/functions.py
@@ -48,11 +48,14 @@ _session.cookies.set_policy(_BlockAllCookies())
 
 
 def timed_get(url, **kwargs):
-    """GET with per-host timing, through the shared keep-alive session."""
+    """GET with per-host timing (default 15s timeout), through the shared keep-alive session."""
     try:
         host = urlparse(url).hostname or "unknown"
     except Exception:
         host = "unknown"
+    # Default timeout: a hung upstream must fail loudly, not pin a session
+    # socket (and its caller's thread) forever. Explicit timeouts always win.
+    kwargs.setdefault("timeout", 15)
     with telemetry.track(f"http.{host}"):
         return _session.get(url, **kwargs)
 

--- a/Helpers/storage.py
+++ b/Helpers/storage.py
@@ -1,7 +1,7 @@
 """
 Helpers/storage.py
-S3-compatible storage abstraction for profile backgrounds, avatar caching,
-and shell exchange icons.
+S3-compatible storage abstraction for profile backgrounds and shell
+exchange icons.
 Currently backed by Supabase Storage (S3-compatible API).
 """
 
@@ -17,8 +17,6 @@ from PIL import Image
 
 from Helpers.logger import log, WARN, ERROR
 from Helpers import telemetry
-
-AVATAR_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days
 
 
 class S3Storage:
@@ -146,18 +144,6 @@ def save_background(bg_id, image: Image.Image):
     """Upload a profile background to S3 and refresh the memory cache."""
     storage.put_image(f"profile_backgrounds/{bg_id}.png", image)
     _bg_cache[bg_id] = image.copy()
-
-
-# --- Avatar cache helpers ---
-
-def get_cached_avatar(uuid: str) -> bytes | None:
-    """Download a cached avatar if it's less than 3 days old."""
-    return storage.get_bytes_if_fresh(f"avatars/{uuid}.png", AVATAR_TTL_SECONDS)
-
-
-def save_cached_avatar(uuid: str, data: bytes):
-    """Upload an avatar to the cache."""
-    storage.put_bytes(f"avatars/{uuid}.png", data)
 
 
 # --- Shell exchange icon helpers ---

--- a/Helpers/storage.py
+++ b/Helpers/storage.py
@@ -7,7 +7,6 @@ Currently backed by Supabase Storage (S3-compatible API).
 
 import io
 import os
-from datetime import datetime, timezone
 
 import certifi
 import boto3
@@ -66,23 +65,6 @@ class S3Storage:
             return Image.open(io.BytesIO(data)).convert("RGBA")
         return None
 
-    def get_bytes_if_fresh(self, key: str, max_age_seconds: int) -> bytes | None:
-        """Return object bytes only if younger than max_age_seconds."""
-        if not self._is_configured:
-            return None
-        try:
-            with telemetry.track("s3.get"):
-                resp = self.client.get_object(Bucket=self._bucket, Key=key)
-                age = (datetime.now(timezone.utc) - resp["LastModified"]).total_seconds()
-                if age > max_age_seconds:
-                    resp["Body"].close()
-                    return None
-                data = resp["Body"].read()
-                resp["Body"].close()
-                return data
-        except Exception:
-            return None
-
     def put_bytes(self, key: str, data: bytes, content_type: str = "image/png"):
         with telemetry.track("s3.put"):
             self.client.put_object(
@@ -124,7 +106,12 @@ def get_background(bg_id) -> Image.Image:
         _bg_cache[bg_id] = img
         return img.copy()
     if bg_id != 1:
-        return get_background(1)
+        try:
+            return get_background(1)
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"Background {bg_id} not found in S3 (fallback background 1 also missing)"
+            ) from None
     if IS_TEST_MODE:
         return Image.open("images/profile_pictures/default.png")
     raise FileNotFoundError(f"Background {bg_id} not found in S3")

--- a/Helpers/storage.py
+++ b/Helpers/storage.py
@@ -107,16 +107,26 @@ storage = S3Storage()
 
 # --- Profile background helpers ---
 
+# In-process cache of profile backgrounds. The bot owns the only write path
+# (save_background), so write-through here gives zero-staleness reads at ~0ms
+# versus the ~300ms S3 round trip Phase 0 measured. Values are the pristine
+# fetched images; reads hand out copies because callers mutate them in place.
+_bg_cache: dict = {}
+
+
 def get_background(bg_id) -> Image.Image:
-    """Download a profile background from S3. Falls back to local default in test mode."""
+    """Profile background from memory, falling back to S3 (then default)."""
     from Helpers.variables import IS_TEST_MODE
+
+    cached = _bg_cache.get(bg_id)
+    if cached is not None:
+        return cached.copy()
     img = storage.get_image(f"profile_backgrounds/{bg_id}.png")
     if img:
-        return img
+        _bg_cache[bg_id] = img
+        return img.copy()
     if bg_id != 1:
-        img = storage.get_image("profile_backgrounds/1.png")
-        if img:
-            return img
+        return get_background(1)
     if IS_TEST_MODE:
         return Image.open("images/profile_pictures/default.png")
     raise FileNotFoundError(f"Background {bg_id} not found in S3")
@@ -133,8 +143,9 @@ def get_background_file(bg_id):
 
 
 def save_background(bg_id, image: Image.Image):
-    """Upload a profile background to S3."""
+    """Upload a profile background to S3 and refresh the memory cache."""
     storage.put_image(f"profile_backgrounds/{bg_id}.png", image)
+    _bg_cache[bg_id] = image.copy()
 
 
 # --- Avatar cache helpers ---

--- a/Helpers/telemetry.py
+++ b/Helpers/telemetry.py
@@ -11,11 +11,29 @@ a command.
 """
 
 import contextvars
+import datetime
 import json
 import os
 import sys
 import time
 from contextlib import contextmanager
+
+
+def queue_ms_from(created, now=None):
+    """Milliseconds between an interaction's creation time and `now`.
+
+    `created` is a timezone-aware datetime (from discord.utils.snowflake_time on
+    the interaction id). Returns None on missing/bad input rather than raising —
+    a telemetry field must never break a command.
+    """
+    try:
+        if created is None:
+            return None
+        if now is None:
+            now = datetime.datetime.now(datetime.timezone.utc)
+        return round((now - created).total_seconds() * 1000.0, 2)
+    except Exception:
+        return None
 
 # Holds the accumulator for the in-flight command invocation.
 #

--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -1064,8 +1064,6 @@ class UpdateMemberData(commands.Cog):
         log(INFO, f"Running snapshot for date: {target_date}", context="update_member_data")
 
         guild = Guild("The Aquarium", "WYNN_LOOP_TOKEN")
-        db = DB()
-        db.connect()
         snap = {'time': int(time.time()), 'members': []}
 
         total_members = len(guild.all_members)
@@ -1092,27 +1090,36 @@ class UpdateMemberData(commands.Cog):
                     failed_members.append(m)
                     continue
 
-                # shells
-                db.cursor.execute(
-                    "SELECT COALESCE(s.shells, 0) "
-                    "FROM discord_links dl "
-                    "LEFT JOIN shells s ON dl.discord_id = s.user "
-                    "WHERE dl.uuid = %s",
-                    (uuid,)
-                )
-                row = db.cursor.fetchone()
-                sh = row[0] if row else 0
+                # Short-lived checkout scoped to this member's reads only. It is
+                # opened after the external API fetch above and closed before the
+                # next iteration's fetch (and before any retry sleep), so no pool
+                # slot is held across an API call or a retry sleep.
+                db = DB()
+                db.connect()
+                try:
+                    # shells
+                    db.cursor.execute(
+                        "SELECT COALESCE(s.shells, 0) "
+                        "FROM discord_links dl "
+                        "LEFT JOIN shells s ON dl.discord_id = s.user "
+                        "WHERE dl.uuid = %s",
+                        (uuid,)
+                    )
+                    row = db.cursor.fetchone()
+                    sh = row[0] if row else 0
 
-                # raids
-                db.cursor.execute(
-                    "SELECT COALESCE(ur.uncollected_raids, 0) + COALESCE(ur.collected_raids, 0) "
-                    "FROM discord_links dl "
-                    "LEFT JOIN uncollected_raids ur ON dl.uuid = ur.uuid "
-                    "WHERE dl.uuid = %s",
-                    (uuid,)
-                )
-                row = db.cursor.fetchone()
-                rd = row[0] if row else 0
+                    # raids
+                    db.cursor.execute(
+                        "SELECT COALESCE(ur.uncollected_raids, 0) + COALESCE(ur.collected_raids, 0) "
+                        "FROM discord_links dl "
+                        "LEFT JOIN uncollected_raids ur ON dl.uuid = ur.uuid "
+                        "WHERE dl.uuid = %s",
+                        (uuid,)
+                    )
+                    row = db.cursor.fetchone()
+                    rd = row[0] if row else 0
+                finally:
+                    db.close()
 
                 snap['members'].append({
                     'name': username,
@@ -1141,7 +1148,12 @@ class UpdateMemberData(commands.Cog):
 
         failed_fetches = len(failed_members) if failed_members else 0
 
-        # 3: write to player_activity database table (uses UPSERT for deduplication)
+        # 3: write to player_activity database table (uses UPSERT for deduplication).
+        # Own checkout for the whole write transaction: per-member carry-forward
+        # reads + UPSERTs + a single commit. No API fetches or sleeps happen here,
+        # so the slot is held only for DB work.
+        db = DB()
+        db.connect()
         try:
             db_rows_written = 0
             for member in snap['members']:
@@ -1187,13 +1199,13 @@ class UpdateMemberData(commands.Cog):
             db.connection.commit()
             private_profiles = sum(1 for m in snap['members'] if m.get('playtime') is None)
             log(INFO, f"Snapshot written to DB ({db_rows_written} rows, {failed_fetches} failed API, {private_profiles} private profiles)", context="update_member_data")
-            db.close()
             return (True, db_rows_written, total_members, failed_fetches, private_profiles)
         except Exception as e:
             log(ERROR, f"Failed to write to DB: {e}", context="update_member_data")
             traceback.print_exc()
-            db.close()
             return (False, 0, total_members, failed_fetches, 0)
+        finally:
+            db.close()
 
     @tasks.loop(time=dtime(hour=0, minute=1, tzinfo=timezone.utc))
     async def daily_activity_snapshot(self):

--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -58,6 +58,23 @@ CONTRIBUTION_THRESHOLD = 2_500_000_000
 RATE_LIMIT = 100  # max calls per minute
 RAID_DETECTION_ENABLED = False
 
+EMBED_FIELD_CAP = 25  # Discord rejects embeds with more fields (error 50035)
+
+
+def _build_rank_change_embeds(role_changes, now):
+    """Chunk rank changes into embeds of at most EMBED_FIELD_CAP fields.
+
+    A promotion wave or cold-start diff can exceed 25 changes; a single
+    oversized embed 400s on send and kills the loop (observed in dev with a
+    30-change diff)."""
+    embeds = []
+    for start in range(0, len(role_changes), EMBED_FIELD_CAP):
+        er = discord.Embed(title='Guild Rank Changes', timestamp=now, color=0x0000FF)
+        for _, name, old, new in role_changes[start:start + EMBED_FIELD_CAP]:
+            er.add_field(name=discord.utils.escape_markdown(name), value=f"{old} → {new}", inline=False)
+        embeds.append(er)
+    return embeds
+
 RAID_EMOJIS = {
     "Nest of the Grootslangs": NOTG_EMOJI,
     "The Canyon Colossus": TCC_EMOJI,
@@ -672,13 +689,11 @@ class UpdateMemberData(commands.Cog):
         if role_changes and not (self.cold_start and not self.member_list_exists):
             ch = self.client.get_channel(LOG_CHANNEL)
             guild_log_ch = self.client.get_channel(GUILD_LOG)
-            er = discord.Embed(title='Guild Rank Changes', timestamp=now, color=0x0000FF)
-            for _,name,old,new in role_changes:
-                er.add_field(name=discord.utils.escape_markdown(name),value=f"{old} → {new}",inline=False)
-            if ch:
-                await ch.send(embed=er)
-            if guild_log_ch:
-                await guild_log_ch.send(embed=er)
+            for er in _build_rank_change_embeds(role_changes, now):
+                if ch:
+                    await ch.send(embed=er)
+                if guild_log_ch:
+                    await guild_log_ch.send(embed=er)
 
         # 5: Update presence
         await self.client.change_presence(activity=discord.CustomActivity(name=f"{guild.online} members online"))
@@ -1314,11 +1329,18 @@ class UpdateMemberData(commands.Cog):
 
     @update_member_data.error
     async def on_update_member_data_error(self, error):
-        log(ERROR, "update_member_data loop raised an exception", context="update_member_data")
-        traceback.print_exc()
-        # restart the loop after a short pause
+        log(ERROR, f"update_member_data loop raised: {error!r}", context="update_member_data")
+        traceback.print_exception(type(error), error, error.__traceback__)
+        # This handler is awaited INSIDE the dying loop's own task, so
+        # is_running() is still True here and an inline restart is always
+        # skipped (observed in dev: the loop stayed dead for 75 minutes).
+        # Detach the restart so its check runs after the loop task finishes.
+        asyncio.create_task(self._restart_update_member_data())
+
+    async def _restart_update_member_data(self):
         await asyncio.sleep(5)
         if not self.update_member_data.is_running():
+            log(WARN, "Restarting update_member_data loop after crash", context="update_member_data")
             self.update_member_data.start()
 
 

--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -1063,9 +1063,9 @@ class UpdateMemberData(commands.Cog):
 
         log(INFO, f"Running snapshot for date: {target_date}", context="update_member_data")
 
+        guild = Guild("The Aquarium", "WYNN_LOOP_TOKEN")
         db = DB()
         db.connect()
-        guild = Guild("The Aquarium", "WYNN_LOOP_TOKEN")
         snap = {'time': int(time.time()), 'members': []}
 
         total_members = len(guild.all_members)

--- a/docs/latency-investigation.md
+++ b/docs/latency-investigation.md
@@ -223,13 +223,15 @@ duplicate UUID lookup.)
 
 #### Still open
 
-- Task-loop start-offset staggering (Phase 1 item 2) and the task-fleet split (item 3, parked).
-- `manage rank` runs sync DB on the loop, and `manage link` holds a checkout across a
-  `getPlayerUUID` HTTP call — the two remaining violations of the checkout-after-HTTP
-  discipline; thread them the same way next pass.
-- `BasicPlayerStats` raises `AttributeError` instead of setting `error=True` when its player
-  fetch returns falsy (`Helpers/classes.py`, `pdata.get` on `False`) — pre-existing, now
-  surfaced inside a worker thread by `new_member`.
+- Task-loop start-offset staggering (Phase 1 item 2) — decide after the post-deploy capture
+  shows how much task-loop stall remains.
+- The task-fleet split (item 3) — parked; revisit only if traffic grows enough to congest the
+  loop.
+
+(`manage rank`/`link` loop hygiene and the `BasicPlayerStats` error path — previously listed
+here — are fixed: rank batches its permission reads into one brief checkout and persists via a
+second, link resolves the UUID before connecting and reports an unresolvable ign instead of
+crashing, and `BasicPlayerStats` sets `error=True` when the player-data fetch fails.)
 
 `queue_ms` recorded null for every command in the first window because `discord.Interaction`
 (py-cord 2.6) has no `created_at`; it is now derived from the interaction snowflake id, so the

--- a/docs/latency-investigation.md
+++ b/docs/latency-investigation.md
@@ -1,6 +1,6 @@
 # Command latency investigation
 
-**Status:** Phase 0 is deployed and analysed — see [Findings](#findings--first-two-days-of-telemetry). Phase 1 item 1 (threading + de-cold) is **implemented and awaiting deploy measurement**; item 2 (task-loop staggering) not started; item 3 (fleet split) parked. After deploy: capture, run `scripts/analyze_telemetry.py`, diff against the Findings baseline.
+**Status:** Phase 0 is deployed and analysed — see [Findings](#findings--first-two-days-of-telemetry). Phase 1 (threading + de-cold) and Phase 1.5 (the follow-up sweep: default timeout, full `http.*` coverage, remaining loop-hygiene sites, per-phase snapshot checkouts, pool observability) are **implemented and awaiting deploy measurement**. Still open: task-loop staggering, the parked fleet split, and the [Still open](#still-open) items. After deploy: capture, run `scripts/analyze_telemetry.py`, diff against the Findings baseline.
 
 ## Symptom
 
@@ -100,9 +100,10 @@ Scope limits to keep in mind when reading the data:
 - Timing records are **command-scoped**. Background task loops call the same DB and HTTP layers but
   run outside any command, so their own calls emit no bucket record. Their impact shows up
   indirectly, through `loop_lag` and through `queue_ms` on commands that land mid-cycle.
-- A few `requests.get` calls inside individual command files (snipe, worlds, lootpool, manage,
-  raids, map, progress) are not routed through the timed wrapper, so their HTTP time appears in no
-  `http.*` bucket. The shared hot paths are covered; the picture is not exhaustive.
+- All outbound GETs — shared helpers and every command file — route through the timed wrapper, so
+  the `http.*` picture is complete. (The one non-`timed_get` HTTP call, `Helpers/sheets.py`'s POST,
+  is a deliberate exception: the wrapper is GET-only. `Commands/aspects.py` uses aiohttp, also by
+  design.)
 - A command cancelled mid-flight (shutdown, gateway disconnect) records `ok: true`, because
   py-cord swallows the cancellation before the timing hook runs. Documented, not fixed.
 
@@ -199,16 +200,36 @@ duplicate UUID lookup.)
 3. **Split the task fleet into its own service** — parked. Not justified while the loop is healthy;
    revisit only if traffic grows enough to congest it.
 
-#### Phase 1 follow-ups (deliberate deferrals)
+#### Phase 1.5 — follow-ups (implemented)
 
-- Default timeout in `timed_get` (`kwargs.setdefault("timeout", ...)`) — changes hang→exception
-  behaviour at three timeout-less call sites, so it is a decision, not a tweak.
-- Sweep the remaining bare `requests.get` sites (snipe, lootpool, map, progress, manage, and
-  raids' guild fetch) through `timed_get` so the `http.*` picture is complete.
-- Pool-retry sleeps run synchronously; the few direct-async `DB` call sites (e.g. `manage.py`'s
-  inline `PlayerStats`) can block the loop up to ~0.6 s under real pool contention — pre-existing
-  blocking pattern, bounded, worth threading in the next pass.
-- Per-phase checkouts in `daily_activity_snapshot`; a pool-exhaustion counter/log for visibility.
+- `timed_get` applies a **default 15 s timeout** (explicit timeouts win). A hung upstream now
+  fails loudly instead of pinning a session socket and its worker thread forever. Every swept
+  call site's exception handling was verified to treat the new `Timeout` like any other request
+  failure.
+- **Every `requests.get` under `Commands/` is swept** through `timed_get` — direct calls and the
+  `to_thread(requests.get, …)` callable form (the callable form evaded the call-pattern grep
+  twice; three sites in snipe/lootpool and one in worlds were caught on the second and third
+  passes).
+- **Loop hygiene:** `manage`'s shell modal and shells render path, and `new_member`, now defer
+  first and run their blocking work (HTTP → then DB checkout) in worker threads via module-level
+  sync helpers — the `/profile` pattern. The shell modal also reports helper failures instead of
+  stranding the deferred interaction at "thinking…" (modal errors bypass the command error
+  handler), and the snipe log posts without its image rather than erroring after the success
+  embed was already sent.
+- **`daily_activity_snapshot` takes per-phase checkouts** — no pool slot is held across a
+  per-member API fetch or a retry sleep; the write phase keeps its original single commit.
+- **Pool exhaustion is observable:** `DB.connect` logs a WARN (`"DB pool exhausted, retrying"`)
+  whenever the bounded retry fires — the direct signal that `DB_POOL_MAX` needs raising.
+
+#### Still open
+
+- Task-loop start-offset staggering (Phase 1 item 2) and the task-fleet split (item 3, parked).
+- `manage rank` runs sync DB on the loop, and `manage link` holds a checkout across a
+  `getPlayerUUID` HTTP call — the two remaining violations of the checkout-after-HTTP
+  discipline; thread them the same way next pass.
+- `BasicPlayerStats` raises `AttributeError` instead of setting `error=True` when its player
+  fetch returns falsy (`Helpers/classes.py`, `pdata.get` on `False`) — pre-existing, now
+  surfaced inside a worker thread by `new_member`.
 
 `queue_ms` recorded null for every command in the first window because `discord.Interaction`
 (py-cord 2.6) has no `created_at`; it is now derived from the interaction snowflake id, so the

--- a/docs/latency-investigation.md
+++ b/docs/latency-investigation.md
@@ -1,6 +1,6 @@
 # Command latency investigation
 
-**Status:** Phase 0 is deployed and the first two days have been analysed — see [Findings](#findings--first-two-days-of-telemetry). The measured result promotes H2 (cold connections) over H1 and rescopes the fixes; [Phase 1](#phase-1--fixes-evidence-ranked) is evidence-ranked and not yet started.
+**Status:** Phase 0 is deployed and analysed — see [Findings](#findings--first-two-days-of-telemetry). Phase 1 item 1 (threading + de-cold) is **implemented and awaiting deploy measurement**; item 2 (task-loop staggering) not started; item 3 (fleet split) parked. After deploy: capture, run `scripts/analyze_telemetry.py`, diff against the Findings baseline.
 
 ## Symptom
 
@@ -163,21 +163,52 @@ The data redirects Phase 1: the event loop is not congested, so **splitting the 
 own service — the largest planned change — is not justified.** The win is getting command I/O off
 the loop and making it not-cold.
 
+#### Component benchmark (pre-deploy, real prod services)
+
+| Component | Current path | Proposed path | Gain |
+|---|---|---|---|
+| DB access | fresh connect+query 436 ms | pooled query 153 ms | 2.8× |
+| Wynncraft GET | fresh session 456 ms | shared session 141 ms | 3.2× |
+| Visage GET | fresh session 252 ms (max 1611) | shared session 71 ms | 3.5× |
+| Background read | S3 293 ms | memory hit ~0 ms | — |
+
+Pipeline: sequential-cold ≈ 2648 ms measured → ~700–900 ms expected warm. (Sequential-threaded:
+the avatar URL needs `player.UUID`, which only exists after `PlayerStats` returns, so the avatar
+fetch runs after it rather than in parallel; with keep-alive that costs ~70 ms and avoids a
+duplicate UUID lookup.)
+
 ### Phase 1 — fixes, evidence-ranked
 
-1. **Get command I/O off the loop and de-cold it.** Highest payoff, addresses both the slow command
-   and the loop stalls it causes:
-   - `to_thread` the blocking S3 / avatar-fetch / Pillow work in `profile` and the other card
-     commands.
-   - Attack the S3 cost directly — it is the fattest bucket by far. Backgrounds and avatars are
-     near-static, and the avatar's 3-day cache currently lives in S3, so the cache *read* itself
-     costs 0.7–1.6 s. Move that cache to local disk or an in-process LRU.
-   - Connection pool in `DB` (removes the per-command connect cost) and a warm/keepalive HTTP
-     session (helps visage / Wynncraft).
+1. **Get command I/O off the loop and de-cold it** — **implemented.** What shipped:
+   - Shared keep-alive `requests.Session` behind `timed_get` (stateless: block-all cookie policy,
+     so the three Wynncraft token identities share nothing but sockets).
+   - Connection pool behind `DB` (`ThreadedConnectionPool`, max `DB_POOL_MAX`, default 8; checkout
+     timed in the same `db.connect` bucket; rollback-on-return; broken connections discarded;
+     bounded retry on pool exhaustion, fast-fail on real connection errors). `PlayerStats` and the
+     daily snapshot task check out only after their external HTTP completes, so slots are never
+     held across slow fetches.
+   - Background memory cache with write-through invalidation in `save_background` — a background
+     change shows on the very next render; reads are ~0 ms.
+   - **S3 avatar cache deleted.** Its reads (0.97–1.6 s in prod) cost more than the fresh visage
+     fetch they were avoiding (~71 ms with keep-alive). Skins are now fetched fresh per render —
+     a skin change shows on the next render, bounded only by visage's own CDN.
+   - `/profile`'s card build (Pillow + avatar fetch) moved into a worker thread — renders no
+     longer stall the event loop for everyone else.
 2. **Stagger task-loop start offsets** so `update_member_data` and siblings do not all fire on the
-   same minute boundary — cheap mitigation for the ~300 ms task stalls.
+   same minute boundary — cheap mitigation for the ~300 ms task stalls. Not started.
 3. **Split the task fleet into its own service** — parked. Not justified while the loop is healthy;
    revisit only if traffic grows enough to congest it.
+
+#### Phase 1 follow-ups (deliberate deferrals)
+
+- Default timeout in `timed_get` (`kwargs.setdefault("timeout", ...)`) — changes hang→exception
+  behaviour at three timeout-less call sites, so it is a decision, not a tweak.
+- Sweep the remaining bare `requests.get` sites (snipe, lootpool, map, progress, manage, and
+  raids' guild fetch) through `timed_get` so the `http.*` picture is complete.
+- Pool-retry sleeps run synchronously; the few direct-async `DB` call sites (e.g. `manage.py`'s
+  inline `PlayerStats`) can block the loop up to ~0.6 s under real pool contention — pre-existing
+  blocking pattern, bounded, worth threading in the next pass.
+- Per-phase checkouts in `daily_activity_snapshot`; a pool-exhaustion counter/log for visibility.
 
 `queue_ms` recorded null for every command in the first window because `discord.Interaction`
 (py-cord 2.6) has no `created_at`; it is now derived from the interaction snowflake id, so the
@@ -185,8 +216,13 @@ queue-delay discriminator works from the next deploy onward.
 
 ## Picking this back up
 
-Phase 0 is deployed and the first read is done (see Findings). Re-run the analysis on a fresh
-capture with `scripts/analyze_telemetry.py` (it prints drift health, excursion correlation, and the
-per-command bucket breakdown from a `railway logs --json` dump), then start Phase 1 at item 1 —
-threading the card-command I/O and moving the S3 background/avatar cache off S3. Keep the `db.*` /
-`s3.*` / `http.*` bucket names stable through the fixes so before/after captures stay comparable.
+Phase 1 item 1 is implemented; the next action is deploy-and-measure, not code. Capture a window
+(`railway logs --service worker --since 48h --lines 5000 --json > after.json`), run
+`scripts/analyze_telemetry.py after.json`, and diff against the Findings baseline. Success bar:
+profile `total_ms` median under ~1 s warm, `db.connect` near-zero after the first sample (which
+includes one-time pool construction — use the median, not the max), and no command-coincident loop
+excursions from the render path. Note `http.visage.surgeplay.com` gains events it did not have in
+Phase 0 (raids' avatar fetch is newly routed through `timed_get`), so compare that bucket on
+latency-per-event, not count. Bucket names were kept stable throughout, so before/after captures
+are directly comparable. Then work the follow-ups list above, starting with the `timed_get`
+default-timeout decision.

--- a/docs/latency-investigation.md
+++ b/docs/latency-investigation.md
@@ -1,6 +1,6 @@
 # Command latency investigation
 
-**Status:** Phase 0 instrumentation is implemented (measurement only, behaviourally neutral). It has not yet been analysed — deploy, capture a data window, then work through [Reading the telemetry](#reading-the-telemetry). Phase 1 (the fixes) has not been started.
+**Status:** Phase 0 is deployed and the first two days have been analysed — see [Findings](#findings--first-two-days-of-telemetry). The measured result promotes H2 (cold connections) over H1 and rescopes the fixes; [Phase 1](#phase-1--fixes-evidence-ranked) is evidence-ranked and not yet started.
 
 ## Symptom
 
@@ -39,14 +39,18 @@ The "something is asleep" model does not survive the evidence:
 
 ## Hypotheses, ranked
 
-**H1 — Event-loop contention with the background task fleet.** *(best fit)*
+*This was the ranking before any measurement. The [Findings](#findings--first-two-days-of-telemetry)
+section has the measured result, which reordered these: H2 is the dominant cost and H1 is
+secondary.*
+
+**H1 — Event-loop contention with the background task fleet.** *(pre-measurement: best guess)*
 The task loops in `Tasks/` run on 1/2/3/5/10-minute cycles and several perform blocking work
 directly on the event loop. A command arriving mid-cycle queues behind that work; one arriving in
 a gap returns immediately. The apparent sleep/wake periodicity is the task schedule.
 `Tasks/update_member_data.py` is the prime suspect — it runs every three minutes and iterates the
 full guild roster.
 
-**H2 — Cold connection paths after idle.** *(contributing)*
+**H2 — Cold connection paths after idle.** *(pre-measurement: contributing; measured: dominant)*
 Every database helper opens a fresh TLS connection to Neon. Every outbound API call builds a new
 `requests` session, so nothing reuses a socket. botocore's connection pool idles out. Under
 sustained traffic some of this amortises; after a quiet spell everything re-handshakes at once. A
@@ -134,20 +138,55 @@ Two consequences:
   forward logs to an external sink (Railway suggests Vector / Fluent Bit / OTEL). For a one-off
   investigation, teeing to a file is enough; a forwarder is overkill.
 
-### Phase 1 — fixes, highest payoff first
+### Findings — first two days of telemetry
 
-1. Connection pool in `DB`. Single file, removes N handshakes per command.
-2. Move remaining blocking work off the loop: module-level `requests.Session`, and `to_thread` for
-   the Pillow render and the S3 calls.
-3. Stagger task-loop start offsets so they do not all fire on the same minute boundary.
-4. Split the task fleet into its own service or process so background work cannot contend with
-   interaction handling. This is the real fix for H1 and the largest change — only worth doing if
-   Phase 0 confirms H1.
+Measured over roughly the first day and a half after deployment (~1,800 one-minute drift windows,
+~70 drift excursions, 15 commands). Low command traffic, which is itself part of the story.
+
+- **The event loop is healthy at baseline.** p95 drift is ~2 ms (median across all windows), p90
+  ~2.5 ms. A congested loop is ruled out. Brief single-tick bumps occur (about a quarter of minutes
+  touch >100 ms once) but nothing sustained.
+- **Every command is slow — 2 to 6.5 seconds — and the cost is cold external I/O.** Supabase S3
+  reads dominate: `s3.get` ranged 0.7–4.0 s. Then outbound HTTP (visage avatar, Wynncraft) and
+  fresh DB connects (0.1–0.7 s each, no pool).
+- **H2 (cold connections) is confirmed on real traffic.** Two `profile` calls a minute apart showed
+  `s3.get` drop from ~3.95 s to ~0.73 s — a ~5× cold penalty. With traffic this sparse, paths are
+  almost always cold, so nearly every command is a first-after-idle. That is the reported symptom.
+- **Commands block the loop themselves.** The largest drift excursions (up to ~5.1 s) coincide with
+  commands, because the card-render path runs S3, HTTP and Pillow inline on the event loop. A slow
+  command stalls the loop for everyone during it.
+- **H1 (task contention) is real but secondary.** About half the excursions are
+  `update_member_data`'s recurring ~300 ms stalls; the rest are other task loops. None of this is
+  the main driver of command latency.
+
+The data redirects Phase 1: the event loop is not congested, so **splitting the task fleet into its
+own service — the largest planned change — is not justified.** The win is getting command I/O off
+the loop and making it not-cold.
+
+### Phase 1 — fixes, evidence-ranked
+
+1. **Get command I/O off the loop and de-cold it.** Highest payoff, addresses both the slow command
+   and the loop stalls it causes:
+   - `to_thread` the blocking S3 / avatar-fetch / Pillow work in `profile` and the other card
+     commands.
+   - Attack the S3 cost directly — it is the fattest bucket by far. Backgrounds and avatars are
+     near-static, and the avatar's 3-day cache currently lives in S3, so the cache *read* itself
+     costs 0.7–1.6 s. Move that cache to local disk or an in-process LRU.
+   - Connection pool in `DB` (removes the per-command connect cost) and a warm/keepalive HTTP
+     session (helps visage / Wynncraft).
+2. **Stagger task-loop start offsets** so `update_member_data` and siblings do not all fire on the
+   same minute boundary — cheap mitigation for the ~300 ms task stalls.
+3. **Split the task fleet into its own service** — parked. Not justified while the loop is healthy;
+   revisit only if traffic grows enough to congest it.
+
+`queue_ms` recorded null for every command in the first window because `discord.Interaction`
+(py-cord 2.6) has no `created_at`; it is now derived from the interaction snowflake id, so the
+queue-delay discriminator works from the next deploy onward.
 
 ## Picking this back up
 
-Phase 0 is built and deployed-ready; the next action is to run it and read the output, not to write
-more code. Deploy, let it run through several quiet-then-active cycles, capture the window before it
-ages out, then work through [Reading the telemetry](#reading-the-telemetry). The single
-highest-information signal is the event-loop lag monitor: it either confirms or kills H1, and that
-decides whether Phase 1's task-fleet split is needed at all.
+Phase 0 is deployed and the first read is done (see Findings). Re-run the analysis on a fresh
+capture with `scripts/analyze_telemetry.py` (it prints drift health, excursion correlation, and the
+per-command bucket breakdown from a `railway logs --json` dump), then start Phase 1 at item 1 —
+threading the card-command I/O and moving the S3 background/avatar cache off S3. Keep the `db.*` /
+`s3.*` / `http.*` bucket names stable through the fixes so before/after captures stay comparable.

--- a/main.py
+++ b/main.py
@@ -128,12 +128,14 @@ async def _telemetry_before(ctx: discord.ApplicationContext):
 
     queue_ms is the gap between Discord creating the interaction and the bot
     starting to run it — it separates "the bot was busy" from "the work was slow".
+
+    discord.Interaction (py-cord 2.6) has no `created_at`, so derive the creation
+    time from the interaction's snowflake id, which every interaction carries.
     """
     queue_ms = None
     try:
-        created = ctx.interaction.created_at
-        now = datetime.datetime.now(datetime.timezone.utc)
-        queue_ms = round((now - created).total_seconds() * 1000.0, 2)
+        created = discord.utils.snowflake_time(ctx.interaction.id)
+        queue_ms = telemetry.queue_ms_from(created)
     except Exception:
         pass
 

--- a/main.py
+++ b/main.py
@@ -71,9 +71,15 @@ async def on_ready():
         client.add_view(ApplicationButtonView())
         client.add_view(ApplicationVoteView())
         client.add_view(ThreadVoteView())
-        await client.sync_commands()
-        client.synced = True
-        log(SUCCESS, "Slash commands synced.")
+        try:
+            await client.sync_commands()
+            client.synced = True
+            log(SUCCESS, "Slash commands synced.")
+        except Exception as e:
+            # A sync failure (e.g. 403 when the bot lacks access to one guild)
+            # must not kill the rest of on_ready — presence, the logger flush
+            # loop, and the startup notification all live below this point.
+            log(ERROR, f"Slash command sync failed; continuing startup: {e}")
 
     logger.start()
 

--- a/scripts/analyze_telemetry.py
+++ b/scripts/analyze_telemetry.py
@@ -1,0 +1,150 @@
+"""
+scripts/analyze_telemetry.py
+Summarise Phase 0 latency telemetry from a Railway JSON log dump.
+
+Capture a window (Railway keeps 7 days on the Hobby plan), then analyse it:
+
+    railway logs --service worker --since 48h --lines 5000 --json > phase0.json
+    python scripts/analyze_telemetry.py phase0.json
+
+Reads one JSON object per line (Railway flattens each emitted telemetry record
+into top-level attributes) and prints, in the order the investigation doc says
+to read them:
+
+  1. event-loop drift  (loop_lag_summary  -> is the loop congested?)
+  2. drift excursions  (loop_lag          -> what blocks it, and when?)
+  3. command breakdown (command           -> where does a command's time go?)
+
+Reads from a file argument, or stdin if none is given. Read-only.
+"""
+
+import json
+import sys
+from statistics import median
+
+
+def _load(stream):
+    summaries, excursions, commands, loop_starts = [], [], [], []
+    for line in stream:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except ValueError:
+            continue
+        t = rec.get("type")
+        if t == "loop_lag_summary":
+            summaries.append(rec)
+        elif t == "loop_lag":
+            excursions.append(rec)
+        elif t == "command":
+            commands.append(rec)
+        elif "STARTING LOOP" in (rec.get("message") or ""):
+            loop_starts.append(rec)
+    return summaries, excursions, commands, loop_starts
+
+
+def _pct(values, q):
+    if not values:
+        return 0.0
+    s = sorted(values)
+    idx = max(0, min(len(s) - 1, int(round(q * (len(s) - 1)))))
+    return s[idx]
+
+
+def _buckets(rec):
+    b = rec.get("buckets") or {}
+    if isinstance(b, str):
+        try:
+            b = json.loads(b)
+        except ValueError:
+            b = {}
+    return b
+
+
+def _span(records):
+    ts = [r.get("timestamp", "") for r in records if r.get("timestamp")]
+    return (min(ts), max(ts)) if ts else ("?", "?")
+
+
+def report(summaries, excursions, commands, loop_starts):
+    everything = summaries + excursions + commands + loop_starts
+    lo, hi = _span(everything)
+    print(f"Window: {lo}  ->  {hi}")
+    print(f"Records: {len(summaries)} summaries, {len(excursions)} excursions, "
+          f"{len(commands)} commands\n")
+
+    # 1. Loop health
+    print("== Event-loop drift (loop_lag_summary) ==")
+    if summaries:
+        p95 = [s.get("p95_ms", 0) for s in summaries]
+        mx = [s.get("max_ms", 0) for s in summaries]
+        print(f"  windows            {len(summaries)}")
+        print(f"  p95 drift  median  {median(p95):.2f} ms")
+        print(f"  p95 drift  p90     {_pct(p95, 0.90):.2f} ms")
+        print(f"  p95 drift  max     {max(p95):.2f} ms")
+        print(f"  windows w/ max-tick >100ms  {sum(1 for m in mx if m > 100)}")
+        print(f"  windows w/ max-tick >250ms  {sum(1 for m in mx if m > 250)}")
+        print(f"  windows w/ max-tick >1000ms {sum(1 for m in mx if m > 1000)}")
+    else:
+        print("  (none)")
+
+    # 2. Excursions and what they line up with
+    print("\n== Drift excursions (loop_lag > threshold) ==")
+    if excursions:
+        drifts = [e.get("drift_ms", 0) for e in excursions]
+        cmd_ts = sorted(c.get("ts", 0) for c in commands)
+
+        def near_command(ts):
+            return any(abs(ts - c) < 3 for c in cmd_ts)
+
+        def in_task_window(rec):
+            # update_member_data and siblings fire around :34-:40 of the minute
+            sec = rec.get("timestamp", "")[17:19]
+            return sec.isdigit() and 34 <= int(sec) <= 40
+
+        by_cmd = sum(1 for e in excursions if near_command(e.get("ts", 0)))
+        by_task = sum(1 for e in excursions
+                      if in_task_window(e) and not near_command(e.get("ts", 0)))
+        print(f"  count   {len(excursions)}   range {min(drifts):.0f}-{max(drifts):.0f} ms")
+        print(f"  coincide with a command (±3s)      {by_cmd}   (usually the largest)")
+        print(f"  land in the task-loop second window  {by_task}")
+        print(f"  other                                {len(excursions) - by_cmd - by_task}")
+        print("  largest:")
+        for e in sorted(excursions, key=lambda x: -x.get("drift_ms", 0))[:5]:
+            tag = "  <- command" if near_command(e.get("ts", 0)) else ""
+            print(f"    {e.get('timestamp','?')[11:19]}  {e.get('drift_ms',0):>6.0f} ms{tag}")
+    else:
+        print("  (none)")
+
+    # 3. Commands
+    print("\n== Commands ==")
+    if commands:
+        nulls = sum(1 for c in commands if c.get("queue_ms") is None)
+        if nulls:
+            print(f"  NOTE: queue_ms is null on {nulls}/{len(commands)} records\n")
+        print(f"  {'time':<9} {'command':<16} {'queue':>7} {'total':>7}   top buckets")
+        for c in sorted(commands, key=lambda x: x.get("timestamp", "")):
+            t = c.get("timestamp", "?")[11:19]
+            q = c.get("queue_ms")
+            q = "null" if q is None else f"{q:.0f}"
+            top = sorted(_buckets(c).items(), key=lambda kv: -kv[1].get("ms", 0))[:3]
+            tops = ", ".join(f"{k}={v.get('ms',0):.0f}" for k, v in top)
+            print(f"  {t:<9} {c.get('command','?'):<16} {q:>7} "
+                  f"{c.get('total_ms',0):>7.0f}   {tops}")
+    else:
+        print("  (none)")
+
+
+def main():
+    if len(sys.argv) > 1:
+        with open(sys.argv[1]) as fh:
+            data = _load(fh)
+    else:
+        data = _load(sys.stdin)
+    report(*data)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_background_cache.py
+++ b/tests/test_background_cache.py
@@ -56,3 +56,14 @@ def test_save_background_updates_cache_write_through():
         refreshed = storage.get_background(1)
     s3.assert_not_called()  # served from the updated cache
     assert refreshed.getpixel((0, 0))[2] == 255  # blue
+
+
+def test_double_missing_background_names_original_id():
+    """When both the requested bg and the fallback bg 1 are missing from S3,
+    the error names the originally requested id, not the fallback's."""
+    import Helpers.variables as variables
+
+    with patch.object(storage.storage, "get_image", return_value=None), \
+         patch.object(variables, "IS_TEST_MODE", False):
+        with pytest.raises(FileNotFoundError, match="Background 7"):
+            storage.get_background(7)

--- a/tests/test_background_cache.py
+++ b/tests/test_background_cache.py
@@ -1,0 +1,58 @@
+"""
+Test suite for the profile-background memory cache (Helpers/storage.py).
+
+Tests:
+1. Second get_background for the same id does not hit S3
+2. Returned images are independent copies (mutation cannot poison the cache)
+3. save_background updates the cache in place (write-through invalidation)
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Helpers import storage
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    storage._bg_cache.clear()
+    yield
+    storage._bg_cache.clear()
+
+
+def _img(color):
+    return Image.new("RGBA", (4, 4), color)
+
+
+def test_second_read_is_served_from_memory():
+    with patch.object(storage.storage, "get_image", return_value=_img("red")) as s3:
+        storage.get_background(1)
+        storage.get_background(1)
+    assert s3.call_count == 1
+
+
+def test_returned_image_is_a_copy():
+    with patch.object(storage.storage, "get_image", return_value=_img("red")):
+        first = storage.get_background(1)
+        first.putpixel((0, 0), (0, 0, 0, 0))  # mutate what the caller got
+        second = storage.get_background(1)
+    assert second.getpixel((0, 0)) != (0, 0, 0, 0)
+
+
+def test_save_background_updates_cache_write_through():
+    with patch.object(storage.storage, "get_image", return_value=_img("red")):
+        assert storage.get_background(1).getpixel((0, 0))[0] == 255  # red
+    with patch.object(storage.storage, "put_image") as put:
+        storage.save_background(1, _img("blue"))
+    put.assert_called_once()
+    with patch.object(storage.storage, "get_image") as s3:
+        refreshed = storage.get_background(1)
+    s3.assert_not_called()  # served from the updated cache
+    assert refreshed.getpixel((0, 0))[2] == 255  # blue

--- a/tests/test_basic_player_stats.py
+++ b/tests/test_basic_player_stats.py
@@ -1,0 +1,32 @@
+"""
+Test suite for BasicPlayerStats error paths (Helpers/classes.py).
+
+Tests:
+1. A failed UUID lookup sets error=True (pre-existing behaviour)
+2. A failed player-data fetch sets error=True instead of raising
+   AttributeError on the False that getPlayerDatav3 returns
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Helpers.classes import BasicPlayerStats
+
+
+def test_failed_uuid_lookup_sets_error():
+    with patch("Helpers.classes.getPlayerUUID", return_value=None):
+        stats = BasicPlayerStats("NoSuchPlayer")
+    assert stats.error is True
+
+
+def test_failed_player_data_fetch_sets_error_not_attributeerror():
+    with patch("Helpers.classes.getPlayerUUID", return_value=("Name", "some-uuid")), \
+         patch("Helpers.classes.getPlayerDatav3", return_value=False):
+        stats = BasicPlayerStats("Name")
+    assert stats.error is True

--- a/tests/test_db_pool.py
+++ b/tests/test_db_pool.py
@@ -8,7 +8,8 @@ Tests:
 4. connect() wraps the checkout in the db.connect bucket
 5. A checkout whose post-checkout setup fails is discarded, not leaked
 6. connect() retries getconn() on PoolError and succeeds once the pool frees up
-7. connect() gives up and re-raises PoolError after exhausting retries
+7. connect() logs a WARN each time it retries after a PoolError (exhaustion signal)
+8. connect() gives up and re-raises PoolError after exhausting retries
 """
 
 import os
@@ -125,6 +126,23 @@ def test_connect_retries_pool_error_then_succeeds():
     assert fake.getconn.call_count == 3
     mock_sleep.assert_any_call(0.2)
     mock_sleep.assert_any_call(0.4)
+
+
+def test_connect_logs_warning_when_pool_exhausted_and_retrying():
+    conn = FakeConn()
+    fake = MagicMock()
+    fake.getconn.side_effect = [_pg_pool.PoolError("exhausted"), _pg_pool.PoolError("exhausted"), conn]
+    with patch.object(database, "_get_pool", return_value=fake), \
+         patch.object(database.time, "sleep"), \
+         patch.object(database, "log") as mock_log:
+        db = database.DB()
+        db.connect()
+    assert db.connection is not None
+    warn_messages = [
+        call.args[1] for call in mock_log.call_args_list
+        if len(call.args) >= 2 and "pool exhausted" in str(call.args[1])
+    ]
+    assert len(warn_messages) == 2  # one WARN per retried checkout, not the final success
 
 
 def test_connect_gives_up_after_exhausting_pool_error_retries():

--- a/tests/test_db_pool.py
+++ b/tests/test_db_pool.py
@@ -7,6 +7,8 @@ Tests:
 3. Two sequential DB() uses reuse one underlying connection
 4. connect() wraps the checkout in the db.connect bucket
 5. A checkout whose post-checkout setup fails is discarded, not leaked
+6. connect() retries getconn() on PoolError and succeeds once the pool frees up
+7. connect() gives up and re-raises PoolError after exhausting retries
 """
 
 import os
@@ -14,6 +16,7 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
+from psycopg2 import pool as _pg_pool
 
 # Add project root to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -108,3 +111,28 @@ def test_checkout_discarded_when_post_checkout_setup_fails():
         with pytest.raises(RuntimeError):
             db.connect()
     fake.putconn.assert_called_once_with(conn, close=True)
+
+
+def test_connect_retries_pool_error_then_succeeds():
+    conn = FakeConn()
+    fake = MagicMock()
+    fake.getconn.side_effect = [_pg_pool.PoolError("exhausted"), _pg_pool.PoolError("exhausted"), conn]
+    with patch.object(database, "_get_pool", return_value=fake), \
+         patch.object(database.time, "sleep") as mock_sleep:
+        db = database.DB()
+        db.connect()
+    assert db.connection is not None
+    assert fake.getconn.call_count == 3
+    mock_sleep.assert_any_call(0.2)
+    mock_sleep.assert_any_call(0.4)
+
+
+def test_connect_gives_up_after_exhausting_pool_error_retries():
+    fake = MagicMock()
+    fake.getconn.side_effect = _pg_pool.PoolError("exhausted")
+    with patch.object(database, "_get_pool", return_value=fake), \
+         patch.object(database.time, "sleep"):
+        db = database.DB()
+        with pytest.raises(_pg_pool.PoolError):
+            db.connect()
+    assert fake.getconn.call_count == 3

--- a/tests/test_db_pool.py
+++ b/tests/test_db_pool.py
@@ -1,0 +1,94 @@
+"""
+Test suite for the DB connection pool (Helpers/database.py).
+
+Tests:
+1. close() returns the connection to the pool after rollback, not conn.close()
+2. A broken (closed) connection is discarded with putconn(close=True)
+3. Two sequential DB() uses reuse one underlying connection
+4. connect() wraps the checkout in the db.connect bucket
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Helpers import database, telemetry
+
+
+class FakeConn:
+    def __init__(self):
+        self.closed = 0
+        self.rolled_back = False
+
+    def cursor(self):
+        return MagicMock()
+
+    def rollback(self):
+        self.rolled_back = True
+
+
+@pytest.fixture(autouse=True)
+def _fresh_pool_and_context():
+    token = telemetry._current.set(None)
+    database._reset_pool_for_tests()
+    yield
+    database._reset_pool_for_tests()
+    telemetry._current.reset(token)
+
+
+def _fake_pool(conn):
+    fake = MagicMock()
+    fake.getconn.return_value = conn
+    return fake
+
+
+def test_close_rolls_back_and_returns_to_pool():
+    conn = FakeConn()
+    fake = _fake_pool(conn)
+    with patch.object(database, "_get_pool", return_value=fake):
+        db = database.DB()
+        db.connect()
+        db.close()
+    assert conn.rolled_back is True
+    fake.putconn.assert_called_once()
+    args, kwargs = fake.putconn.call_args
+    assert args[0] is conn
+    assert not kwargs.get("close", False)
+
+
+def test_broken_connection_is_discarded():
+    conn = FakeConn()
+    conn.closed = 1  # psycopg2 marks broken connections with nonzero .closed
+    fake = _fake_pool(conn)
+    with patch.object(database, "_get_pool", return_value=fake):
+        db = database.DB()
+        db.connect()
+        db.close()
+    fake.putconn.assert_called_once_with(conn, close=True)
+
+
+def test_sequential_uses_share_one_connection():
+    conn = FakeConn()
+    fake = _fake_pool(conn)
+    with patch.object(database, "_get_pool", return_value=fake):
+        for _ in range(2):
+            db = database.DB()
+            db.connect()
+            db.close()
+    assert fake.getconn.call_count == 2
+    assert fake.putconn.call_count == 2  # same pool, checkout/return both times
+
+
+def test_checkout_is_timed_into_db_connect():
+    conn = FakeConn()
+    fake = _fake_pool(conn)
+    telemetry.begin("test", None, None, None)
+    with patch.object(database, "_get_pool", return_value=fake):
+        db = database.DB()
+        db.connect()
+    assert telemetry._current.get().buckets["db.connect"]["n"] == 1

--- a/tests/test_db_pool.py
+++ b/tests/test_db_pool.py
@@ -6,6 +6,7 @@ Tests:
 2. A broken (closed) connection is discarded with putconn(close=True)
 3. Two sequential DB() uses reuse one underlying connection
 4. connect() wraps the checkout in the db.connect bucket
+5. A checkout whose post-checkout setup fails is discarded, not leaked
 """
 
 import os
@@ -92,3 +93,18 @@ def test_checkout_is_timed_into_db_connect():
         db = database.DB()
         db.connect()
     assert telemetry._current.get().buckets["db.connect"]["n"] == 1
+
+
+class FakeConnBrokenCursor(FakeConn):
+    def cursor(self):
+        raise RuntimeError("cursor setup failed")
+
+
+def test_checkout_discarded_when_post_checkout_setup_fails():
+    conn = FakeConnBrokenCursor()
+    fake = _fake_pool(conn)
+    with patch.object(database, "_get_pool", return_value=fake):
+        db = database.DB()
+        with pytest.raises(RuntimeError):
+            db.connect()
+    fake.putconn.assert_called_once_with(conn, close=True)

--- a/tests/test_rank_change_embeds.py
+++ b/tests/test_rank_change_embeds.py
@@ -1,0 +1,43 @@
+"""
+Test suite for rank-change embed chunking (Tasks/update_member_data.py).
+
+A 30-change diff (promotion wave / cold start) previously produced one
+31-field embed, which Discord rejects (50035) — and the send failure killed
+the update loop. Embeds must chunk at 25 fields.
+"""
+
+import datetime
+import os
+import sys
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Tasks.update_member_data import EMBED_FIELD_CAP, _build_rank_change_embeds
+
+NOW = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+
+
+def _changes(n):
+    return [(f"uuid{i}", f"Player{i}", "Piranha", "Angler") for i in range(n)]
+
+
+def test_30_changes_chunk_into_two_embeds():
+    embeds = _build_rank_change_embeds(_changes(30), NOW)
+    assert len(embeds) == 2
+    assert len(embeds[0].fields) == EMBED_FIELD_CAP
+    assert len(embeds[1].fields) == 5
+
+
+def test_no_embed_exceeds_discord_field_cap():
+    for n in (1, 24, 25, 26, 50, 51):
+        for er in _build_rank_change_embeds(_changes(n), NOW):
+            assert len(er.fields) <= 25
+
+
+def test_all_changes_present_and_ordered():
+    embeds = _build_rank_change_embeds(_changes(27), NOW)
+    names = [f.name for er in embeds for f in er.fields]
+    assert names == [f"Player{i}" for i in range(27)]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -182,3 +182,33 @@ def test_cancellation_is_not_visible_to_after_hook():
 
     asyncio.run(main())
     assert seen["exc"] is None
+
+
+def test_queue_ms_from_computes_positive_delay():
+    import datetime
+    now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    created = now - datetime.timedelta(milliseconds=1500)
+    assert telemetry.queue_ms_from(created, now=now) == pytest.approx(1500.0, abs=0.5)
+
+
+def test_queue_ms_from_returns_none_on_bad_input():
+    assert telemetry.queue_ms_from(None) is None
+    assert telemetry.queue_ms_from("not-a-datetime") is None
+
+
+def test_snowflake_derivation_matches_created_time():
+    """The hook derives queue delay from the interaction snowflake id (since
+    discord.Interaction has no created_at). Build an id for a known instant and
+    confirm the derived delay is correct — this is the path the fix relies on."""
+    import datetime
+    import discord
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    created = now - datetime.timedelta(milliseconds=1200)
+    # Discord snowflake: ((ms_since_discord_epoch) << 22)
+    discord_epoch_ms = 1420070400000
+    ms = int(created.timestamp() * 1000) - discord_epoch_ms
+    fake_id = ms << 22
+
+    derived = discord.utils.snowflake_time(fake_id)
+    assert telemetry.queue_ms_from(derived, now=now) == pytest.approx(1200.0, abs=2.0)

--- a/tests/test_timed_get.py
+++ b/tests/test_timed_get.py
@@ -5,6 +5,7 @@ Tests:
 1. Timing lands in a bucket named for the URL's host
 2. The response object is returned unchanged
 3. A URL with no parseable host uses the 'unknown' bucket
+4. The shared session never stores or sends cookies (stateless across token identities)
 """
 
 import os
@@ -55,3 +56,14 @@ def test_timed_get_uses_shared_session():
     assert out == "r"
     mock_get.assert_called_once()
     mock_bare.assert_not_called()
+
+
+def test_session_blocks_all_cookies():
+    """The session is shared across three token identities; a shared cookie
+    jar (e.g. Cloudflare's __cf_bm) would leak state between them and isn't
+    thread-safe to write. The policy must refuse to set or send cookies."""
+    from Helpers import functions
+
+    policy = functions._session.cookies.get_policy()
+    assert policy.set_ok(None, None) is False
+    assert policy.return_ok(None, None) is False

--- a/tests/test_timed_get.py
+++ b/tests/test_timed_get.py
@@ -29,7 +29,7 @@ def _reset_context():
 
 def test_timed_get_buckets_by_host():
     telemetry.begin("test", None, None, None)
-    with patch("Helpers.functions.requests.get", return_value="response") as mock_get:
+    with patch("Helpers.functions._session.get", return_value="response") as mock_get:
         result = timed_get("https://api.wynncraft.com/v3/player/x", timeout=10)
     assert result == "response"
     mock_get.assert_called_once_with("https://api.wynncraft.com/v3/player/x", timeout=10)
@@ -38,6 +38,20 @@ def test_timed_get_buckets_by_host():
 
 def test_timed_get_without_host_uses_unknown():
     telemetry.begin("test", None, None, None)
-    with patch("Helpers.functions.requests.get", return_value="response"):
+    with patch("Helpers.functions._session.get", return_value="response"):
         timed_get("not-a-url")
     assert telemetry._current.get().buckets["http.unknown"]["n"] == 1
+
+
+def test_timed_get_uses_shared_session():
+    """All calls must go through the module-level session (keep-alive), never
+    bare requests.get — that is the entire point of the session."""
+    from Helpers import functions
+
+    assert isinstance(functions._session, __import__("requests").Session)
+    with patch("Helpers.functions._session.get", return_value="r") as mock_get, \
+         patch("Helpers.functions.requests.get") as mock_bare:
+        out = timed_get("https://api.wynncraft.com/v3/x")
+    assert out == "r"
+    mock_get.assert_called_once()
+    mock_bare.assert_not_called()

--- a/tests/test_timed_get.py
+++ b/tests/test_timed_get.py
@@ -67,3 +67,16 @@ def test_session_blocks_all_cookies():
     policy = functions._session.cookies.get_policy()
     assert policy.set_ok(None, None) is False
     assert policy.return_ok(None, None) is False
+
+
+def test_timed_get_applies_default_timeout():
+    """Timeout-less callers get a 15s default instead of hanging forever."""
+    with patch("Helpers.functions._session.get", return_value="r") as mock_get:
+        timed_get("https://api.mojang.com/x")
+    assert mock_get.call_args.kwargs["timeout"] == 15
+
+
+def test_timed_get_explicit_timeout_wins():
+    with patch("Helpers.functions._session.get", return_value="r") as mock_get:
+        timed_get("https://api.wynncraft.com/x", timeout=6)
+    assert mock_get.call_args.kwargs["timeout"] == 6


### PR DESCRIPTION
Two stages of the latency investigation on one branch: the follow-up items from the first telemetry read, then the Phase 1 fixes those findings justified.

## Follow-up (first three commits)

- **Fix `queue_ms`** — recorded `null` on every command: `discord.Interaction` (py-cord 2.6) has no `created_at`, so the hook's extraction raised and was swallowed. Now derived from the interaction snowflake id, unit-tested in `telemetry.queue_ms_from`.
- **`scripts/analyze_telemetry.py`** — one command turns a `railway logs --json` capture into the drift-health / excursion-correlation / per-command-bucket readout, making the before/after a single diff.
- **Findings folded into `docs/latency-investigation.md`** — loop healthy at baseline (p95 drift ~2 ms), commands slow (2–6.5 s) from cold external I/O with Supabase S3 dominating, cold-connection penalty confirmed ~5× on real traffic. Consequence: the task-fleet split is parked; the win is threading command I/O and de-colding it.

## Phase 1 (the fixes)

Measured component benchmark first (real prod services): DB fresh connect+query 436 ms → pooled 153 ms; Wynncraft GET 456 → 141 ms; visage GET 252 → 71 ms; background S3 read 293 ms → memory ~0 ms. Pipeline projection ≈ 2648 → ~700–900 ms warm.

1. **Shared keep-alive `requests.Session`** behind `timed_get` — all routed call sites benefit, no call-site changes. Stateless (block-all cookie policy) so the three Wynncraft token identities share nothing but sockets.
2. **Connection pool behind `DB`** (`ThreadedConnectionPool`, max `DB_POOL_MAX` default 8). `connect()`/`close()` keep their signatures, so all helpers work unchanged; checkout is timed in the same `db.connect` bucket for a clean before/after. Rollback-on-return, broken-connection discard, bounded retry on exhaustion with fast-fail on real connection errors. `PlayerStats` and the daily snapshot check out only **after** their external HTTP completes, so slots are never pinned across slow fetches.
3. **Background memory cache** with write-through invalidation in `save_background` — a background change shows on the very next render; repeat reads ~0 ms. Copies handed out on every path (callers mutate images in place).
4. **S3 avatar cache deleted.** Its reads measured 0.97–1.6 s in prod — slower than the fresh visage fetch it existed to avoid (~71 ms with keep-alive). Skins are fetched fresh per render: a skin change now shows on the next render, bounded only by visage's CDN. Applied across `profile`, `raids` (also newly routed through `timed_get`), and `aspects`.
5. **`/profile` card build moved off the event loop** into `_build_profile_card` via `asyncio.to_thread` — Phase 0 caught renders stalling the loop 2–5 s each; that stops. Extraction verified line-identical and depth-preserved mechanically.

**Freshness semantics:** skin change → next render (no bot-side staleness); background change → next render (zero staleness).

## After merge

Deploy, let it run a day, then: `railway logs --service worker --since 48h --lines 5000 --json > after.json && python scripts/analyze_telemetry.py after.json` and diff against the doc's Findings baseline. Success bar: profile `total_ms` median under ~1 s warm, `db.connect` near-zero after the first sample, no command-coincident loop excursions. Deliberate deferrals are listed in the doc (`timed_get` default timeout, remaining bare `requests.get` sweep, per-phase snapshot checkouts).

## Tests

84 passed, 2 warnings (both pre-existing third-party import-time deprecations). New coverage: pool checkout/return/discard/retry, cache copy-independence and write-through, session reuse + cookie policy, `queue_ms` derivation.

## Phase 1.5 — the follow-up sweep (8 commits)

Closes every deliberate deferral from the Phase 1 review, plus what the pass itself uncovered:

- **Default 15s timeout in `timed_get`** (explicit timeouts win). Sanctioned failure-path change: previously timeout-less calls now fail loudly instead of hanging — and a hung upstream no longer pins a session socket + worker thread forever. Exception handling at every swept site verified to absorb the new `Timeout` like any other request failure.
- **Complete `http.*` coverage:** every `requests.get` under `Commands/` now routes through `timed_get` — including three `to_thread(requests.get, …)` callable-form sites the call-pattern grep missed twice (snipe, lootpool ×2) and a fourth in worlds caught by the final review. Zero bare fetches remain; `sheets.py`'s POST and `aspects`' aiohttp are documented deliberate exceptions.
- **Loop hygiene finished for the known sites:** `manage`'s shell modal + shells render and `new_member` now defer first and thread their blocking work (HTTP before DB checkout, `/profile` pattern). Hardening from the review: the shell modal reports failures instead of stranding at "thinking…" (modal errors bypass the command error handler), and the snipe log degrades to text-only if its image fetch fails.
- **`daily_activity_snapshot` uses per-phase pooled checkouts** — no slot held across per-member API fetches or retry sleeps; same single commit point.
- **Pool exhaustion is observable:** `DB.connect` WARNs (`"DB pool exhausted, retrying"`) whenever the bounded retry fires — the direct signal for raising `DB_POOL_MAX`.
- Regression test for the double-missing-background error message.

Still open (documented in the doc): task-loop staggering (decide after the post-deploy capture) and the parked fleet split. The `manage rank`/`link` loop-hygiene and `BasicPlayerStats` error-path items were subsequently fixed on this branch (rank batches reads into one brief checkout and persists via a second; link resolves the UUID before connecting and reports an unresolvable ign instead of raising TypeError; BasicPlayerStats sets error=True on a failed fetch). Tests: 90 passed.

**Tests: 88 passed**, 2 warnings (both pre-existing third-party import-time deprecations).

## Dev-environment verification + 3 crash fixes

The full stack was tested in the dev environment (TEST_MODE: test bot, local Postgres, Dev S3 bucket) before merge: a 17/17 headless integration battery over the command internals, then two live boots of the bot.

**Measured (dev, real APIs):** warm `/profile` pipeline **515 ms** (prod baseline 2,350–6,547 ms); `db.connect` 0.02 ms warm; background read 0.24 ms from memory (was 0.7–4 s from S3); avatar 72 ms via keep-alive. Write paths (`link`/`rank` helpers, background save-invalidation) round-tripped against dev-only stores with cleanup. Live: loop drift p95 ~1–2 ms, heartbeats every minute, zero pool exhaustion.

**The live run surfaced three real crash paths, all fixed here:**
- **Rank-change embeds now chunk at Discord's 25-field cap.** A 30-change diff produced one oversized embed; the send 400'd (error 50035) and killed the `update_member_data` loop. Would have fired in prod on any promotion wave touching >25 members. (+3 tests)
- **The loop's crash-restart handler was dead code.** It checked `is_running()` from inside the dying loop's own task — always True, so the restart was always skipped (observed: loop dead for 75 minutes with the handler present). The restart is now a detached task whose check runs after the loop task actually finishes.
- **`on_ready` survives a `sync_commands` failure** (e.g. 403 when the bot lacks access to one guild): logs and continues, so presence, the log flush loop, and the startup notification still run. Verified on the second boot: sync failed (dev bot isn't in every guild), startup completed, and `update_member_data` ran clean 3-minute cycles.

**Tests: 93 passed**, 2 warnings (pre-existing third-party import-time deprecations).


🤖 Generated with [Claude Code](https://claude.com/claude-code)



