### PR TITLE
Only write territory snapshot to DB when it changed

### DIFF
--- a/Tasks/territory_tracker.py
+++ b/Tasks/territory_tracker.py
@@ -318,7 +318,13 @@ class TerritoryTracker(commands.Cog):
             if not new_data:
                 return
 
-            await asyncio.to_thread(saveTerritoryData, new_data)
+            # Write-on-change: the full snapshot is ~350KB and rewriting it
+            # every tick dominates Railway egress. Skipping identical writes
+            # loses nothing (the stored bytes would be the same), and because
+            # old_data is re-read from the DB each tick, a missing or diverged
+            # row fails the comparison and gets rewritten on the next pass.
+            if new_data != old_data:
+                await asyncio.to_thread(saveTerritoryData, new_data)
 
             # tally post-update counts
             new_counts = Counter()

--- a/tests/test_territory_tracker.py
+++ b/tests/test_territory_tracker.py
@@ -1,0 +1,92 @@
+"""Tests for the territory tracker's write-on-change persistence.
+
+The snapshot write is the bot's dominant egress cost, so the loop must only
+write when the fetched data differs from what the DB already holds — while
+still rewriting when the row is missing (self-heal after external deletion).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from Tasks import territory_tracker as tt
+from Tasks.territory_tracker import TerritoryTracker
+
+
+def _terr(guild_name, prefix, acquired="2026-01-01T00:00:00Z"):
+    return {
+        "guild": {"uuid": "u", "name": guild_name, "prefix": prefix},
+        "acquired": acquired,
+        "location": {"start": [0, 0], "end": [1, 1]},
+    }
+
+
+def _snapshot():
+    return {
+        "Alpha Plains": _terr("Guild A", "AAA"),
+        "Beta Woods": _terr("Guild B", "BBB"),
+    }
+
+
+def _make_cog():
+    cog = TerritoryTracker.__new__(TerritoryTracker)
+    client = MagicMock()
+    client.is_ready.return_value = True
+    # Home tracker channel exists (loop returns early without it);
+    # global/military channels absent so no embeds are attempted.
+    client.get_channel.side_effect = (
+        lambda cid: MagicMock() if cid == tt.TERRITORY_TRACKER_CHANNEL_ID else None
+    )
+    cog.client = client
+    return cog
+
+
+async def _run_tick(monkeypatch, old_data, new_data):
+    saves = []
+    exchanges = []
+    monkeypatch.setattr(tt, "_read_territories_sync", lambda: old_data)
+    monkeypatch.setattr(tt, "saveTerritoryData", lambda data: saves.append(data))
+    monkeypatch.setattr(
+        tt, "save_territory_exchanges", lambda changes: exchanges.append(changes)
+    )
+
+    async def fake_fetch():
+        return new_data
+
+    monkeypatch.setattr(tt, "getTerritoryData", fake_fetch)
+
+    cog = _make_cog()
+    await TerritoryTracker.territory_tracker.coro(cog)
+    return saves, exchanges
+
+
+@pytest.mark.asyncio
+async def test_identical_snapshot_skips_write(monkeypatch):
+    saves, exchanges = await _run_tick(monkeypatch, _snapshot(), _snapshot())
+    assert saves == []
+    assert exchanges == []
+
+
+@pytest.mark.asyncio
+async def test_ownership_change_writes_and_records_exchange(monkeypatch):
+    old = _snapshot()
+    new = _snapshot()
+    new["Alpha Plains"] = _terr("Guild C", "CCC", acquired="2026-01-02T00:00:00Z")
+
+    saves, exchanges = await _run_tick(monkeypatch, old, new)
+
+    assert saves == [new]
+    assert len(exchanges) == 1
+    assert exchanges[0]["Alpha Plains"]["new"]["owner"] == "Guild C"
+
+
+@pytest.mark.asyncio
+async def test_missing_row_rewrites(monkeypatch):
+    saves, _ = await _run_tick(monkeypatch, {}, _snapshot())
+    assert saves == [_snapshot()]
+
+
+@pytest.mark.asyncio
+async def test_failed_fetch_writes_nothing(monkeypatch):
+    saves, _ = await _run_tick(monkeypatch, _snapshot(), False)
+    assert saves == []


### PR DESCRIPTION
## Summary

The territory tracker loop rewrote the full ~350KB territory snapshot to `cache_entries` every 10 seconds whether or not anything changed — ~8,640 writes/day, ~3GB/day of database egress, which was the dominant line (~$4.60/mo of ~$5.45) in Railway network costs.

This adds a write-on-change guard: the loop already re-reads the previous snapshot from the DB each tick, so the write is now skipped when the fetched data compares equal to what is stored. Writes only happen on ticks where territory ownership actually changed.

## Why this is safe

- **No information loss** — skipping an identical write stores the same bytes that are already there. All alerting/diff logic (claim alerts, exchange log, embeds) runs off the in-loop comparison and is untouched.
- **Self-healing preserved** — because `old_data` is re-read from the DB every tick, a missing or externally-deleted row fails the equality check and is rewritten within 10s, same recovery as before. (The website's `cleanupExpired()` would delete this always-expired row if ever wired up; this design stays immune to that.)
- **Round-trip equality verified empirically** — a live 437-territory snapshot (353.6KB) saved through `saveTerritoryData` and read back through `_read_territories_sync` compares `==` to the original, so the guard doesn't silently degrade into writing every tick.
- **Website unaffected** — `/api/territories` does a plain `SELECT` with no freshness check on read; only `created_at`/`fetch_count` stop bumping every 10s, which surfaces solely in the diagnostic `/api/cache` endpoint (which already reports this key as expired by design).

## Tests

New `tests/test_territory_tracker.py` drives the actual loop callback:
- identical snapshot → no write
- ownership change → write + exchange recorded
- missing DB row → rewrite (self-heal)
- failed API fetch → no write

Full suite: 126 passed.

## Expected result

Territory egress drops from ~92GB/mo to low single-digit GB, bringing total Railway usage back to roughly the included Hobby credit. Watch `NETWORK_TX_GB` in the Railway usage API a day or two after deploy (~3GB/day → well under 0.5GB/day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)