### PR TITLE
feat: auto-transcribe closed applications

### DIFF
--- a/Commands/app_commands.py
+++ b/Commands/app_commands.py
@@ -1,13 +1,13 @@
 import asyncio
 import json
 from datetime import datetime, timezone
-from io import BytesIO
 
 import discord
 from discord import SlashCommandGroup, ApplicationContext
 from discord.ext import commands
 
 from Helpers.classes import BasicPlayerStats
+from Helpers.app_transcript import post_transcript, stamp_transcribed, TranscriptError
 from Helpers.database import DB
 from Helpers.embed_updater import update_web_poll_embed
 from Helpers.functions import generate_applicant_info, getPlayerUUID, getPlayerDatav3
@@ -531,84 +531,17 @@ class WebAppCommands(commands.Cog):
         channel, app = result
         guild = self.client.get_guild(channel.guild.id) or channel.guild
 
-        # Find the archive channel by name
+        try:
+            await post_transcript(self.client, channel, app)
+        except TranscriptError as e:
+            await ctx.followup.send(str(e), ephemeral=True)
+            return
+
+        await asyncio.to_thread(stamp_transcribed, app["id"])
+
         archive_chan = discord.utils.get(guild.text_channels, name=APP_ARCHIVE_CHANNEL_NAME)
-        if not archive_chan:
-            await ctx.followup.send(
-                f"Archive channel `#{APP_ARCHIVE_CHANNEL_NAME}` not found.",
-                ephemeral=True,
-            )
-            return
-
-        # Fetch all messages
-        messages = []
-        async for msg in channel.history(limit=500, oldest_first=True):
-            messages.append(msg)
-
-        if not messages:
-            await ctx.followup.send("No messages found in this channel.", ephemeral=True)
-            return
-
-        # Build transcript
-        ign = (app["answers"].get("ign") or "").strip()
-        type_label = "Guild Member" if app["application_type"] == "guild" else "Community Member"
-        created_at = messages[0].created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
-
-        transcript_lines = [
-            f"=== Application Transcript ===",
-            f"Channel: #{channel.name}",
-            f"Type: {type_label}",
-            f"Applicant: {app['discord_username']} ({app['discord_id']})",
-            f"IGN: {ign or 'N/A'}",
-            f"Status: {app['status']}",
-            f"Created: {created_at}",
-            f"Messages: {len(messages)}",
-            f"{'=' * 40}",
-            "",
-        ]
-
-        for msg in messages:
-            timestamp = msg.created_at.strftime("%Y-%m-%d %H:%M:%S")
-            author = msg.author.display_name
-            bot_tag = " [BOT]" if msg.author.bot else ""
-            transcript_lines.append(f"[{timestamp}] {author}{bot_tag}")
-
-            if msg.content:
-                transcript_lines.append(msg.content)
-
-            for embed in msg.embeds:
-                if embed.title:
-                    transcript_lines.append(f"  [Embed: {embed.title}]")
-                if embed.description:
-                    transcript_lines.append(f"  {embed.description}")
-                for field in embed.fields:
-                    transcript_lines.append(f"  {field.name}: {field.value}")
-
-            for att in msg.attachments:
-                transcript_lines.append(f"  [Attachment: {att.filename} — {att.url}]")
-
-            transcript_lines.append("")
-
-        transcript_text = "\n".join(transcript_lines)
-
-        # Build summary embed
-        embed = discord.Embed(
-            title=f"Transcript: #{channel.name}",
-            color=0x2F3136,
-        )
-        embed.add_field(name="Type", value=type_label, inline=True)
-        embed.add_field(name="Status", value=app["status"].title(), inline=True)
-        embed.add_field(name="Applicant", value=f"<@{app['discord_id']}>", inline=True)
-        if ign:
-            embed.add_field(name="IGN", value=ign, inline=True)
-        embed.add_field(name="Messages", value=str(len(messages)), inline=True)
-
-        # Send as file attachment
-        buf = BytesIO(transcript_text.encode("utf-8"))
-        file = discord.File(buf, filename=f"transcript-{channel.name}.txt")
-
-        await archive_chan.send(embed=embed, file=file)
-        await ctx.followup.send(f"Transcript saved to {archive_chan.mention}.", ephemeral=True)
+        dest = archive_chan.mention if archive_chan else f"#{APP_ARCHIVE_CHANNEL_NAME}"
+        await ctx.followup.send(f"Transcript saved to {dest}.", ephemeral=True)
 
     # --- DB helpers ---
 

--- a/Events/on_guild_channel_update.py
+++ b/Events/on_guild_channel_update.py
@@ -40,6 +40,17 @@ class OnGuildChannelUpdate(commands.Cog):
         if not row:
             return
 
+        # Record when the ticket was first closed (drives auto-transcribe timing).
+        db = DB(); db.connect()
+        try:
+            db.cursor.execute(
+                "UPDATE applications SET closed_at = NOW() WHERE channel_id = %s AND closed_at IS NULL",
+                (after.id,),
+            )
+            db.connection.commit()
+        finally:
+            db.close()
+
         app_type, status, app_id, answers, app_number = row
         if isinstance(answers, str):
             answers = json.loads(answers)

--- a/Helpers/app_transcript.py
+++ b/Helpers/app_transcript.py
@@ -1,0 +1,142 @@
+import datetime
+from io import BytesIO
+
+import discord
+
+from Helpers.database import DB
+from Helpers.variables import APP_ARCHIVE_CHANNEL_NAME
+
+CLOSED_POLL_STATUS = ":red_circle: Closed"
+AUTO_TRANSCRIBE_DELAY = datetime.timedelta(days=3)
+
+
+class TranscriptError(Exception):
+    """Raised when a transcript cannot be posted.
+
+    `retryable` distinguishes a transient/config problem (e.g. archive channel
+    missing — retry later, do NOT advance the queue) from a permanent one
+    (e.g. empty channel — advance past it).
+    """
+
+    def __init__(self, message, *, retryable):
+        super().__init__(message)
+        self.retryable = retryable
+
+
+def classify_transcript_candidate(head, now, delay=AUTO_TRANSCRIBE_DELAY):
+    """Decide what to do with the lowest un-transcribed ticket (`head`).
+
+    `head` is a dict with keys `poll_status`, `channel_id`, `effective_closed_at`,
+    or None when there is no un-transcribed ticket.
+
+    Returns:
+        "none"       -- nothing to do
+        "wait"       -- head not ready (still open, no close time, or delay not elapsed)
+        "skip"       -- closed but no channel to transcribe; advance past it
+        "transcribe" -- closed, has a channel, and the delay has elapsed
+    """
+    if head is None:
+        return "none"
+    if head.get("poll_status") != CLOSED_POLL_STATUS:
+        return "wait"  # still open -> blocks higher tickets (strict order)
+    if not head.get("channel_id"):
+        return "skip"  # closed but nothing to transcribe
+    closed_at = head.get("effective_closed_at")
+    if closed_at is None:
+        return "wait"  # closed with no timestamp -> don't transcribe blindly
+    if closed_at + delay > now:
+        return "wait"  # 3-day delay not elapsed
+    return "transcribe"
+
+
+def build_transcript_text(app, messages, channel_name):
+    """Build the plain-text transcript body for an application channel. Pure."""
+    ign = (app["answers"].get("ign") or "").strip()
+    type_label = "Guild Member" if app["application_type"] == "guild" else "Community Member"
+    created_at = messages[0].created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    lines = [
+        "=== Application Transcript ===",
+        f"Channel: #{channel_name}",
+        f"Type: {type_label}",
+        f"Applicant: {app['discord_username']} ({app['discord_id']})",
+        f"IGN: {ign or 'N/A'}",
+        f"Status: {app['status']}",
+        f"Created: {created_at}",
+        f"Messages: {len(messages)}",
+        "=" * 40,
+        "",
+    ]
+
+    for msg in messages:
+        timestamp = msg.created_at.strftime("%Y-%m-%d %H:%M:%S")
+        author = msg.author.display_name
+        bot_tag = " [BOT]" if msg.author.bot else ""
+        lines.append(f"[{timestamp}] {author}{bot_tag}")
+
+        if msg.content:
+            lines.append(msg.content)
+
+        for embed in msg.embeds:
+            if embed.title:
+                lines.append(f"  [Embed: {embed.title}]")
+            if embed.description:
+                lines.append(f"  {embed.description}")
+            for field in embed.fields:
+                lines.append(f"  {field.name}: {field.value}")
+
+        for att in msg.attachments:
+            lines.append(f"  [Attachment: {att.filename} — {att.url}]")
+
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+async def post_transcript(client, channel, app):
+    """Transcribe `channel` to the archive channel. Raises TranscriptError on
+    failure; returns True on success. Does not touch the DB or the source channel."""
+    guild = channel.guild
+    archive_chan = discord.utils.get(guild.text_channels, name=APP_ARCHIVE_CHANNEL_NAME)
+    if not archive_chan:
+        raise TranscriptError(
+            f"Archive channel `#{APP_ARCHIVE_CHANNEL_NAME}` not found.", retryable=True
+        )
+
+    messages = []
+    async for msg in channel.history(limit=500, oldest_first=True):
+        messages.append(msg)
+
+    if not messages:
+        raise TranscriptError("No messages found in this channel.", retryable=False)
+
+    ign = (app["answers"].get("ign") or "").strip()
+    type_label = "Guild Member" if app["application_type"] == "guild" else "Community Member"
+    transcript_text = build_transcript_text(app, messages, channel.name)
+
+    embed = discord.Embed(title=f"Transcript: #{channel.name}", color=0x2F3136)
+    embed.add_field(name="Type", value=type_label, inline=True)
+    embed.add_field(name="Status", value=app["status"].title(), inline=True)
+    embed.add_field(name="Applicant", value=f"<@{app['discord_id']}>", inline=True)
+    if ign:
+        embed.add_field(name="IGN", value=ign, inline=True)
+    embed.add_field(name="Messages", value=str(len(messages)), inline=True)
+
+    buf = BytesIO(transcript_text.encode("utf-8"))
+    file = discord.File(buf, filename=f"transcript-{channel.name}.txt")
+    await archive_chan.send(embed=embed, file=file)
+    return True
+
+
+def stamp_transcribed(app_id):
+    """Mark an application transcribed so the auto-transcribe queue advances past it."""
+    db = DB()
+    db.connect()
+    try:
+        db.cursor.execute(
+            "UPDATE applications SET transcribed_at = NOW() WHERE id = %s",
+            (app_id,),
+        )
+        db.connection.commit()
+    finally:
+        db.close()

--- a/Tasks/check_apps.py
+++ b/Tasks/check_apps.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+from datetime import datetime, timezone
 
 import discord
 from discord.ext import tasks, commands
@@ -6,6 +8,12 @@ from discord.ext import tasks, commands
 from Helpers.logger import log, INFO, ERROR
 from Helpers.database import DB
 from Helpers.functions import getPlayerDatav3, getPlayerUUID
+from Helpers.app_transcript import (
+    classify_transcript_candidate,
+    post_transcript,
+    stamp_transcribed,
+    TranscriptError,
+)
 from Helpers.variables import APP_MANAGER_ROLE_MENTION, TAQ_GUILD_ID, CLOSED_CATEGORY_NAME, is_home_guild
 
 
@@ -237,12 +245,133 @@ class CheckApps(commands.Cog):
     async def before_auto_close_web_apps(self):
         await self.client.wait_until_ready()
 
+    # --- Auto-transcribe for closed applications ---
+
+    @staticmethod
+    def _fetch_transcript_head():
+        """Return the lowest-numbered un-transcribed guild/community ticket, or None.
+
+        This single row is the head of line: a lower un-transcribed ticket always
+        gates higher ones (strict order)."""
+        db = DB()
+        db.connect()
+        try:
+            db.cursor.execute(
+                """SELECT id, app_number, application_type, discord_id, discord_username,
+                          status, answers, poll_status, channel_id,
+                          COALESCE(closed_at, reviewed_at) AS effective_closed_at
+                     FROM applications
+                    WHERE application_type IN ('guild', 'community')
+                      AND app_number IS NOT NULL
+                      AND transcribed_at IS NULL
+                    ORDER BY app_number ASC
+                    LIMIT 1"""
+            )
+            row = db.cursor.fetchone()
+        finally:
+            db.close()
+
+        if not row:
+            return None
+
+        (app_id, app_number, application_type, discord_id, discord_username,
+         status, answers, poll_status, channel_id, effective_closed_at) = row
+        if isinstance(answers, str):
+            answers = json.loads(answers)
+        return {
+            "id": app_id,
+            "app_number": app_number,
+            "application_type": application_type,
+            "discord_id": discord_id,
+            "discord_username": discord_username,
+            "status": status,
+            "answers": answers or {},
+            "poll_status": poll_status,
+            "channel_id": channel_id,
+            "effective_closed_at": effective_closed_at,
+        }
+
+    # Safety bound: max tickets to transcribe in a single tick. The backlog is at
+    # most a few dozen; this only guards against a logic bug looping forever.
+    AUTO_TRANSCRIBE_MAX_PER_TICK = 100
+
+    @tasks.loop(minutes=5)
+    async def auto_transcribe_apps(self):
+        """Auto-transcribe closed guild/community apps to the archive channel,
+        strictly in app_number order, 3 days after they were closed. Drains every
+        currently-eligible ticket in this tick (sequential sends preserve order);
+        stops at the first ticket that is not yet ready.
+        Guild restriction: operates exclusively on TAQ_GUILD_ID (home guild)."""
+        guild = self.client.get_guild(TAQ_GUILD_ID)
+        if not guild:
+            return
+
+        for _ in range(self.AUTO_TRANSCRIBE_MAX_PER_TICK):
+            head = await asyncio.to_thread(self._fetch_transcript_head)
+            decision = classify_transcript_candidate(head, datetime.now(timezone.utc))
+
+            if decision in ("none", "wait"):
+                return  # nothing left, or the next ticket in order isn't ready — stop.
+
+            if decision == "skip":
+                await asyncio.to_thread(stamp_transcribed, head["id"])
+                log(INFO, f"Skipped app {head['id']} (#{head['app_number']}): no channel to transcribe.",
+                    context="check_apps")
+                continue
+
+            # decision == "transcribe": resolve the channel; a deleted channel becomes a skip.
+            channel = self.client.get_channel(head["channel_id"])
+            if channel is None:
+                try:
+                    channel = await self.client.fetch_channel(head["channel_id"])
+                except Exception:
+                    await asyncio.to_thread(stamp_transcribed, head["id"])
+                    log(INFO, f"Skipped app {head['id']} (#{head['app_number']}): channel "
+                              f"{head['channel_id']} unresolvable.", context="check_apps")
+                    continue
+
+            app = {
+                "id": head["id"],
+                "application_type": head["application_type"],
+                "discord_id": head["discord_id"],
+                "discord_username": head["discord_username"] or str(head["id"]),
+                "status": head["status"],
+                "answers": head["answers"],
+            }
+
+            try:
+                await post_transcript(self.client, channel, app)
+            except TranscriptError as e:
+                if e.retryable:
+                    # Transient/config problem (e.g. archive channel missing). Stop the tick
+                    # without advancing so we retry this same ticket next tick — never skip ahead.
+                    log(ERROR, f"Transcript for app {head['id']} (#{head['app_number']}) failed, "
+                               f"will retry: {e}", context="check_apps")
+                    return
+                log(INFO, f"App {head['id']} (#{head['app_number']}): {e} Marking transcribed.",
+                    context="check_apps")
+                await asyncio.to_thread(stamp_transcribed, head["id"])
+                continue
+
+            await asyncio.to_thread(stamp_transcribed, head["id"])
+            log(INFO, f"Auto-transcribed app {head['id']} (#{head['app_number']}).", context="check_apps")
+        else:
+            log(INFO, f"auto_transcribe_apps hit the per-tick cap "
+                      f"({self.AUTO_TRANSCRIBE_MAX_PER_TICK}); remaining tickets continue next tick.",
+                context="check_apps")
+
+    @auto_transcribe_apps.before_loop
+    async def before_auto_transcribe_apps(self):
+        await self.client.wait_until_ready()
+
     @commands.Cog.listener()
     async def on_ready(self):
         if not self.check_guild_leave.is_running():
             self.check_guild_leave.start()
         if not self.auto_close_web_apps.is_running():
             self.auto_close_web_apps.start()
+        if not self.auto_transcribe_apps.is_running():
+            self.auto_transcribe_apps.start()
 
 
 def setup(client):

--- a/schema.sql
+++ b/schema.sql
@@ -528,7 +528,9 @@ CREATE TABLE IF NOT EXISTS applications (
   bot_processed     BOOLEAN      DEFAULT FALSE,
   invite_image      TEXT,
   app_number        INT,
-  message_ids       BIGINT[]     DEFAULT NULL
+  message_ids       BIGINT[]     DEFAULT NULL,
+  closed_at         TIMESTAMPTZ,
+  transcribed_at    TIMESTAMPTZ
 );
 
 CREATE TABLE IF NOT EXISTS application_votes (

--- a/tests/test_app_transcript.py
+++ b/tests/test_app_transcript.py
@@ -1,0 +1,94 @@
+import datetime
+
+from Helpers.app_transcript import (
+    classify_transcript_candidate,
+    AUTO_TRANSCRIBE_DELAY,
+    CLOSED_POLL_STATUS,
+)
+
+UTC = datetime.timezone.utc
+NOW = datetime.datetime(2026, 7, 27, 12, 0, tzinfo=UTC)
+
+
+def _head(**overrides):
+    base = {
+        "poll_status": CLOSED_POLL_STATUS,
+        "channel_id": 123,
+        "effective_closed_at": NOW - datetime.timedelta(days=4),
+    }
+    base.update(overrides)
+    return base
+
+
+def test_none_when_no_head():
+    assert classify_transcript_candidate(None, NOW) == "none"
+
+
+def test_wait_when_head_still_open():
+    assert classify_transcript_candidate(_head(poll_status=":green_circle: Received"), NOW) == "wait"
+
+
+def test_skip_when_no_channel():
+    assert classify_transcript_candidate(_head(channel_id=None), NOW) == "skip"
+
+
+def test_wait_when_delay_not_elapsed():
+    assert classify_transcript_candidate(_head(effective_closed_at=NOW - datetime.timedelta(days=2)), NOW) == "wait"
+
+
+def test_wait_when_no_closed_timestamp():
+    assert classify_transcript_candidate(_head(effective_closed_at=None), NOW) == "wait"
+
+
+def test_transcribe_when_closed_and_elapsed():
+    assert classify_transcript_candidate(_head(), NOW) == "transcribe"
+
+
+def test_transcribe_exactly_at_boundary():
+    assert classify_transcript_candidate(_head(effective_closed_at=NOW - AUTO_TRANSCRIBE_DELAY), NOW) == "transcribe"
+
+
+from types import SimpleNamespace
+
+from Helpers.app_transcript import build_transcript_text
+
+
+def _msg(content="hi there", author_name="Alice", bot=False):
+    return SimpleNamespace(
+        created_at=datetime.datetime(2026, 7, 20, 9, 30, tzinfo=UTC),
+        author=SimpleNamespace(display_name=author_name, bot=bot),
+        content=content,
+        embeds=[],
+        attachments=[],
+    )
+
+
+def test_build_transcript_text_includes_header_and_body():
+    app = {
+        "answers": {"ign": "Zorak"},
+        "application_type": "guild",
+        "discord_username": "alice",
+        "discord_id": "42",
+        "status": "accepted",
+    }
+    text = build_transcript_text(app, [_msg()], "accepted-3726-zorak")
+    assert "=== Application Transcript ===" in text
+    assert "Channel: #accepted-3726-zorak" in text
+    assert "Type: Guild Member" in text
+    assert "IGN: Zorak" in text
+    assert "Alice" in text
+    assert "hi there" in text
+
+
+def test_build_transcript_text_community_label_and_bot_tag():
+    app = {
+        "answers": {},
+        "application_type": "community",
+        "discord_username": "bob",
+        "discord_id": "7",
+        "status": "denied",
+    }
+    text = build_transcript_text(app, [_msg(author_name="TortBot", bot=True)], "c-denied-3727-bob")
+    assert "Type: Community Member" in text
+    assert "IGN: N/A" in text
+    assert "TortBot [BOT]" in text


### PR DESCRIPTION
## What & why

Transcribing a closed application to `#applications-archive` was manual (`/app transcribe`). This adds an auto-transcribe background loop that mirrors the existing auto-close loop: closed guild/community tickets are transcribed automatically **3 days after they close**, **strictly in `app_number` order** for clean recordkeeping.

## How it works

- **`Helpers/app_transcript.py` (new)** — one home for transcript logic: a pure classifier (`classify_transcript_candidate`), a pure transcript builder (`build_transcript_text`), the IO `post_transcript`, and `stamp_transcribed`. `TranscriptError` separates retryable (config) from permanent failures.
- **`Tasks/check_apps.py`** — new `auto_transcribe_apps` loop. Each tick drains every currently-eligible ticket in ascending `app_number` order; sequential `await`ed sends keep the archive in order. It stops at the first not-yet-ready ticket (still open / <3 days), retries retryable failures without skipping ahead, and skip-marks deleted-channel tickets so the queue can't stall. Bounded per tick as a safety net.
- **`Events/on_guild_channel_update.py`** — stamps `closed_at` when a ticket first lands in the Closed category (drives the 3-day timer).
- **`Commands/app_commands.py`** — `/app transcribe` now reuses `post_transcript` and stamps `transcribed_at`, so manual and automatic transcripts share one sequence.
- **`schema.sql`** — adds nullable `closed_at`, `transcribed_at` to `applications`.

**Scope:** guild/community only (hammerhead excluded). Existing closed backlog is included via `COALESCE(closed_at, reviewed_at)`.

## Testing

- Unit tests for the classifier (order/delay/skip gates) and the transcript builder — full suite: **139 passed**.
- End-to-end on the dev bot + dev DB + dev Discord: verified a real transcript posts to the archive and stamps `transcribed_at`, and that a deleted-channel ticket is skip-marked rather than blocking the queue.

## Required deploy steps (operational, not in the diff)

1. **Migrate the DB** (additive, idempotent):
   ```sql
   ALTER TABLE applications ADD COLUMN IF NOT EXISTS closed_at TIMESTAMPTZ;
   ALTER TABLE applications ADD COLUMN IF NOT EXISTS transcribed_at TIMESTAMPTZ;
   ```
2. **Seed already-transcribed history** so the loop resumes cleanly instead of re-archiving the backlog. The old manual command wrote nothing to the DB, so every row is `transcribed_at = NULL`; the archive channel shows guild/community tickets `3722–3840` were already transcribed. Mark them:
   ```sql
   UPDATE applications SET transcribed_at = NOW()
    WHERE application_type IN ('guild','community')
      AND app_number BETWEEN 3722 AND 3840
      AND transcribed_at IS NULL;
   ```
   After seeding, the loop resumes at `#3841`. Run 1 & 2 **before** deploying the code.
