### PR TITLE
feat: delete application channels after transcript

### DIFF
--- a/Commands/app_commands.py
+++ b/Commands/app_commands.py
@@ -7,7 +7,12 @@ from discord import SlashCommandGroup, ApplicationContext
 from discord.ext import commands
 
 from Helpers.classes import BasicPlayerStats
-from Helpers.app_transcript import post_transcript, stamp_transcribed, TranscriptError
+from Helpers.app_transcript import (
+    post_transcript,
+    stamp_transcribed,
+    delete_transcribed_channel,
+    TranscriptError,
+)
 from Helpers.database import DB
 from Helpers.embed_updater import update_web_poll_embed
 from Helpers.functions import generate_applicant_info, getPlayerUUID, getPlayerDatav3
@@ -541,7 +546,19 @@ class WebAppCommands(commands.Cog):
 
         archive_chan = discord.utils.get(guild.text_channels, name=APP_ARCHIVE_CHANNEL_NAME)
         dest = archive_chan.mention if archive_chan else f"#{APP_ARCHIVE_CHANNEL_NAME}"
-        await ctx.followup.send(f"Transcript saved to {dest}.", ephemeral=True)
+        # Confirm before deleting — this command is often run inside the channel being removed.
+        await ctx.followup.send(f"Transcript saved to {dest}. Deleting this channel…", ephemeral=True)
+
+        try:
+            await delete_transcribed_channel(self.client, app["id"], app["channel_id"])
+        except Exception as e:
+            try:
+                await ctx.followup.send(
+                    f"⚠️ Transcript is saved, but the channel couldn't be deleted: {e}",
+                    ephemeral=True,
+                )
+            except Exception:
+                pass
 
     # --- DB helpers ---
 

--- a/Helpers/app_transcript.py
+++ b/Helpers/app_transcript.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 from io import BytesIO
 
@@ -140,3 +141,36 @@ def stamp_transcribed(app_id):
         db.connection.commit()
     finally:
         db.close()
+
+
+def stamp_channel_deleted(app_id):
+    """Mark a transcribed application's channel as deleted so cleanup won't retry it."""
+    db = DB()
+    db.connect()
+    try:
+        db.cursor.execute(
+            "UPDATE applications SET channel_deleted_at = NOW() WHERE id = %s",
+            (app_id,),
+        )
+        db.connection.commit()
+    finally:
+        db.close()
+
+
+async def delete_transcribed_channel(client, app_id, channel_id):
+    """Delete a transcribed ticket's channel, then stamp channel_deleted_at.
+
+    Idempotent: a channel that is already gone (NotFound) is treated as deleted and
+    still stamped. Transient errors (e.g. Forbidden) propagate so the caller can log
+    and retry on a later pass — channel_deleted_at is only stamped once the channel
+    is confirmed gone.
+    """
+    channel = client.get_channel(channel_id) if channel_id else None
+    if channel is None and channel_id:
+        try:
+            channel = await client.fetch_channel(channel_id)
+        except discord.NotFound:
+            channel = None  # already gone -> treat as deleted
+    if channel is not None:
+        await channel.delete(reason="Application transcribed and archived")
+    await asyncio.to_thread(stamp_channel_deleted, app_id)

--- a/Tasks/check_apps.py
+++ b/Tasks/check_apps.py
@@ -12,6 +12,7 @@ from Helpers.app_transcript import (
     classify_transcript_candidate,
     post_transcript,
     stamp_transcribed,
+    delete_transcribed_channel,
     TranscriptError,
 )
 from Helpers.variables import APP_MANAGER_ROLE_MENTION, TAQ_GUILD_ID, CLOSED_CATEGORY_NAME, is_home_guild
@@ -297,15 +298,20 @@ class CheckApps(commands.Cog):
 
     @tasks.loop(minutes=5)
     async def auto_transcribe_apps(self):
-        """Auto-transcribe closed guild/community apps to the archive channel,
-        strictly in app_number order, 3 days after they were closed. Drains every
-        currently-eligible ticket in this tick (sequential sends preserve order);
-        stops at the first ticket that is not yet ready.
-        Guild restriction: operates exclusively on TAQ_GUILD_ID (home guild)."""
+        """Auto-transcribe closed guild/community apps to the archive channel, then
+        delete the transcribed channels. Guild restriction: operates exclusively on
+        TAQ_GUILD_ID (home guild)."""
         guild = self.client.get_guild(TAQ_GUILD_ID)
         if not guild:
             return
 
+        await self._drain_transcripts()
+        await self._delete_transcribed_channels()
+
+    async def _drain_transcripts(self):
+        """Transcribe every currently-eligible ticket this tick, strictly in
+        app_number order (sequential sends preserve order); stop at the first ticket
+        that is not yet ready."""
         for _ in range(self.AUTO_TRANSCRIBE_MAX_PER_TICK):
             head = await asyncio.to_thread(self._fetch_transcript_head)
             decision = classify_transcript_candidate(head, datetime.now(timezone.utc))
@@ -343,7 +349,7 @@ class CheckApps(commands.Cog):
                 await post_transcript(self.client, channel, app)
             except TranscriptError as e:
                 if e.retryable:
-                    # Transient/config problem (e.g. archive channel missing). Stop the tick
+                    # Transient/config problem (e.g. archive channel missing). Stop the drain
                     # without advancing so we retry this same ticket next tick — never skip ahead.
                     log(ERROR, f"Transcript for app {head['id']} (#{head['app_number']}) failed, "
                                f"will retry: {e}", context="check_apps")
@@ -356,9 +362,46 @@ class CheckApps(commands.Cog):
             await asyncio.to_thread(stamp_transcribed, head["id"])
             log(INFO, f"Auto-transcribed app {head['id']} (#{head['app_number']}).", context="check_apps")
         else:
-            log(INFO, f"auto_transcribe_apps hit the per-tick cap "
+            log(INFO, f"_drain_transcripts hit the per-tick cap "
                       f"({self.AUTO_TRANSCRIBE_MAX_PER_TICK}); remaining tickets continue next tick.",
                 context="check_apps")
+
+    async def _delete_transcribed_channels(self):
+        """Delete channels of already-transcribed guild/community tickets and mark
+        them (channel_deleted_at), so transcribed applications don't linger in Closed
+        Applications. Covers both the historical backlog and tickets just transcribed
+        this tick. Idempotent — an already-gone channel is simply marked."""
+        rows = await asyncio.to_thread(self._fetch_channels_to_delete)
+        for app_id, app_number, channel_id in rows:
+            try:
+                await delete_transcribed_channel(self.client, app_id, channel_id)
+                log(INFO, f"Deleted transcribed channel for app {app_id} (#{app_number}).",
+                    context="check_apps")
+            except Exception as e:
+                # Transient failure (e.g. missing perms) — leave channel_deleted_at NULL so
+                # this ticket is retried on a later tick.
+                log(ERROR, f"Could not delete channel for app {app_id} (#{app_number}): {e}",
+                    context="check_apps")
+
+    @staticmethod
+    def _fetch_channels_to_delete():
+        """Transcribed guild/community tickets whose channel hasn't been deleted yet."""
+        db = DB()
+        db.connect()
+        try:
+            db.cursor.execute(
+                """SELECT id, app_number, channel_id FROM applications
+                    WHERE application_type IN ('guild', 'community')
+                      AND transcribed_at IS NOT NULL
+                      AND channel_deleted_at IS NULL
+                      AND channel_id IS NOT NULL
+                    ORDER BY app_number ASC
+                    LIMIT %s""",
+                (CheckApps.AUTO_TRANSCRIBE_MAX_PER_TICK,)
+            )
+            return db.cursor.fetchall()
+        finally:
+            db.close()
 
     @auto_transcribe_apps.before_loop
     async def before_auto_transcribe_apps(self):

--- a/schema.sql
+++ b/schema.sql
@@ -530,7 +530,8 @@ CREATE TABLE IF NOT EXISTS applications (
   app_number        INT,
   message_ids       BIGINT[]     DEFAULT NULL,
   closed_at         TIMESTAMPTZ,
-  transcribed_at    TIMESTAMPTZ
+  transcribed_at    TIMESTAMPTZ,
+  channel_deleted_at TIMESTAMPTZ
 );
 
 CREATE TABLE IF NOT EXISTS application_votes (


### PR DESCRIPTION
## What & why

Follow-up to the auto-transcribe feature. Transcribing (manual `/app transcribe` and the auto loop) archived the ticket but left the channel sitting in **Closed Applications**. This deletes the channel once its transcript is safely in the archive — for **both** paths — and cleans up the existing backlog of already-transcribed-but-undeleted channels (e.g. #3841–#3871).

## How it works

- **`Helpers/app_transcript.py`** — `delete_transcribed_channel(client, app_id, channel_id)` deletes the channel then stamps `channel_deleted_at`. Idempotent: a channel that's already gone (`NotFound`) is treated as deleted and still stamped; transient errors (e.g. missing perms) propagate so it's retried on a later pass rather than marked done. Adds `stamp_channel_deleted`.
- **`Commands/app_commands.py`** — `/app transcribe` deletes the channel after a successful transcript. The confirmation is sent **first**, since the command usually runs inside the channel being removed.
- **`Tasks/check_apps.py`** — `auto_transcribe_apps` now runs a deletion sweep (`_delete_transcribed_channels`) each tick after the transcribe drain. It deletes channels for **any** transcribed guild/community ticket not yet marked deleted, so it covers both freshly transcribed tickets and the historical backlog. Bounded per tick.
- **`schema.sql`** — adds nullable `channel_deleted_at`.

**Safety:** a channel is only deleted for tickets already marked `transcribed_at`, so it's never removed before its transcript is in the archive. Deletion targets guild/community tickets only (matching the transcribe scope).

## Backlog note

On deploy, the sweep will delete channels for **all** currently transcribed guild/community tickets whose channels still exist — that's #3841–#3871 (the recent auto-transcribed batch) plus any of the older 3722–3840 whose channels weren't manually deleted. Already-gone channels are just marked, no-op. If you'd rather scope this to only the newer batch, say so and I'll bound it.

## Testing

- Full suite: **135 passed**.
- Dev end-to-end (dev bot + dev DB + dev Discord): a live channel was actually deleted and `channel_deleted_at` stamped; an already-gone channel was marked without error (idempotent); a second pass found nothing to do.

## Required deploy step (operational, not in the diff)

Run the migration on the DB before deploying (additive, idempotent):
```sql
ALTER TABLE applications ADD COLUMN IF NOT EXISTS channel_deleted_at TIMESTAMPTZ;
```
No seed needed — existing transcribed rows have `channel_deleted_at = NULL`, which the sweep correctly reads as "not yet deleted."
