### PR TITLE
fix: vanity roles silently skipped every recent joiner

### DIFF
--- a/Helpers/database.py
+++ b/Helpers/database.py
@@ -339,6 +339,37 @@ def get_player_activity_baselines_for_members_with_db(db: DB, key: str, days: in
         raise BatchBaselineQueryError(f"Failed to load batched baselines for key={key}") from e
 
 
+def get_members_with_baseline_history_with_db(db: DB, joined_dates_by_uuid: dict[str, datetime.date | None]) -> set[str]:
+    """Return the uuids that have at least one snapshot in their current membership period.
+
+    The baseline helpers above return (0, True) both for "no snapshot at all" and for
+    a legitimate zero. Callers that turn a baseline into a delta on a lifetime-cumulative
+    column (wars) must tell those apart: a 0 baseline for a member with no history yet
+    credits them their entire lifetime total. Use this to drop those members instead.
+    """
+    if not joined_dates_by_uuid:
+        return set()
+
+    values_sql = []
+    params = []
+    for uuid, joined_date in joined_dates_by_uuid.items():
+        values_sql.append("(%s::uuid, %s::date)")
+        params.extend((uuid, joined_date))
+
+    db.cursor.execute(f"""
+        WITH input(uuid, joined_date) AS (
+            VALUES {", ".join(values_sql)}
+        )
+        SELECT i.uuid FROM input i
+        WHERE EXISTS (
+            SELECT 1 FROM player_activity pa
+            WHERE pa.uuid = i.uuid
+              AND (i.joined_date IS NULL OR pa.snapshot_date >= i.joined_date)
+        )
+    """, tuple(params))
+    return {str(row[0]) for row in db.cursor.fetchall()}
+
+
 def _get_baseline_from_db(db: DB, uuid: str, key: str, days: int, joined_date: datetime.date = None) -> tuple:
     """Core baseline lookup logic.
 

--- a/Tasks/vanity_roles.py
+++ b/Tasks/vanity_roles.py
@@ -13,7 +13,12 @@ from discord import default_permissions
 from dateutil import parser as dateutil_parser
 
 from Helpers.logger import log, INFO, WARN, ERROR
-from Helpers.database import DB, get_current_guild_data
+from Helpers.database import (
+    DB,
+    get_current_guild_data_with_db,
+    get_members_with_baseline_history_with_db,
+    get_player_activity_baselines_for_members_with_db,
+)
 from Helpers.variables import HOME_GUILD_IDS, TAQ_GUILD_ID, ANNOUNCEMENT_CHANNEL_ID, FAQ_CHANNEL_ID, VANITY_ROLE_IDS
 
 START_DATE_UTC = date(2025, 8, 31)  # first run date (YYYY, M, D)
@@ -38,85 +43,67 @@ def _get_current_value(cur_by_uuid: Dict[str, Dict[str, Any]], uuid: str, key: s
         return 0
 
 
-def _get_baseline_from_db(db: DB, uuid: str, key: str, window_days: int, joined_date=None) -> Optional[int]:
-    """
-    Get baseline value from player_activity database table using index-based lookup.
-    Returns None if player has no record for the target date (new member),
-    or if the target date falls before the member's current join date.
-    """
-    try:
-        # Get the window_days-th most recent snapshot date (0-indexed)
-        db.cursor.execute("""
-            SELECT DISTINCT snapshot_date FROM player_activity
-            ORDER BY snapshot_date DESC
-            OFFSET %s LIMIT 1
-        """, (window_days,))
-        date_row = db.cursor.fetchone()
-        if not date_row:
-            return None  # Not enough snapshots in database
-        target_date = date_row[0]
-
-        # If the target date is before the member's current join date,
-        # any snapshot from that date is from a previous membership
-        if joined_date is not None and target_date < joined_date:
-            return None
-
-        db.cursor.execute(f"""
-            SELECT {key} FROM player_activity
-            WHERE uuid = %s AND snapshot_date = %s
-        """, (uuid, target_date))
-        row = db.cursor.fetchone()
-
-        if row is None:
-            return None  # Player has no record for this date (new member)
-        if row[0] is None:
-            return 0
-        return int(row[0])
-    except Exception as e:
-        log(ERROR, f"Error getting baseline for {uuid}/{key}: {e}", context="vanity_roles")
-        return None
-
-
 def compute_windowed_stats(window_days: int = WINDOW_DAYS) -> Dict[str, WindowedStats]:
     """
     Returns { uuid -> WindowedStats(wars=Δ, raids=Δ) } for the last `window_days`.
     Uses current guild data (live) minus baseline from player_activity database table.
-    """
-    # Load current live data from database (updated every 3 minutes)
-    current = get_current_guild_data()
-    cur_members = current.get("members", []) if isinstance(current, dict) else []
-    cur_by_uuid = {m["uuid"]: m for m in cur_members if isinstance(m, dict) and m.get("uuid")}
 
-    # Get baseline values from database
+    Baselines come from the shared Helpers.database helpers, the same ones /activity
+    and /leaderboard use. A member who joined mid-window has no snapshot from
+    `window_days` ago, so those helpers fall back to their earliest snapshot inside the
+    current membership period — i.e. everything they earned since joining counts. The
+    task used to keep its own baseline lookup that returned None in that case and
+    skipped the member outright, which silently excluded every recent joiner (17 of 148
+    members when this was found).
+    """
     db = DB()
     db.connect()
-
-    out: Dict[str, WindowedStats] = {}
     try:
-        for uuid in cur_by_uuid.keys():
-            # Parse member's current join date to filter out old membership snapshots
-            raw_joined = cur_by_uuid[uuid].get('joined')
+        # Live data from the cache table (refreshed every 3 minutes)
+        current = get_current_guild_data_with_db(db)
+        cur_members = current.get("members", []) if isinstance(current, dict) else []
+        cur_by_uuid = {m["uuid"]: m for m in cur_members if isinstance(m, dict) and m.get("uuid")}
+        if not cur_by_uuid:
+            return {}
+
+        # Join dates scope baselines to the current membership, so a returning member
+        # isn't credited progress from a previous stint.
+        joined_dates_by_uuid: Dict[str, Optional[date]] = {}
+        for uuid, member in cur_by_uuid.items():
+            raw_joined = member.get("joined")
             try:
-                member_joined_date = dateutil_parser.isoparse(raw_joined).date() if raw_joined else None
+                joined_dates_by_uuid[uuid] = dateutil_parser.isoparse(raw_joined).date() if raw_joined else None
             except Exception:
-                member_joined_date = None
+                joined_dates_by_uuid[uuid] = None
 
-            curr_wars = _get_current_value(cur_by_uuid, uuid, "wars")
-            curr_raids = _get_current_value(cur_by_uuid, uuid, "raids")
+        # Members with no snapshot yet in this membership have no measurable baseline.
+        # They must be skipped, not treated as baseline 0: `wars` is a lifetime-cumulative
+        # counter, so a 0 baseline would award someone their whole career's wars on day one.
+        measurable = get_members_with_baseline_history_with_db(db, joined_dates_by_uuid)
 
-            base_wars = _get_baseline_from_db(db, uuid, "wars", window_days, joined_date=member_joined_date)
-            base_raids = _get_baseline_from_db(db, uuid, "raids", window_days, joined_date=member_joined_date)
-
-            # Skip players without baseline data (mid-period joins, returning members)
-            if base_wars is None or base_raids is None:
-                continue
-
-            wars_delta = max(curr_wars - base_wars, 0)
-            raids_delta = max(curr_raids - base_raids, 0)
-            out[uuid] = WindowedStats(wars=wars_delta, raids=raids_delta)
+        base_wars = get_player_activity_baselines_for_members_with_db(db, "wars", window_days, joined_dates_by_uuid)
+        base_raids = get_player_activity_baselines_for_members_with_db(db, "raids", window_days, joined_dates_by_uuid)
     finally:
         db.close()
 
+    out: Dict[str, WindowedStats] = {}
+    skipped = 0
+    for uuid in cur_by_uuid:
+        if uuid not in measurable:
+            skipped += 1
+            continue
+        curr_wars = _get_current_value(cur_by_uuid, uuid, "wars")
+        curr_raids = _get_current_value(cur_by_uuid, uuid, "raids")
+        wars_baseline, _ = base_wars.get(uuid, (0, True))
+        raids_baseline, _ = base_raids.get(uuid, (0, True))
+        out[uuid] = WindowedStats(
+            wars=max(curr_wars - wars_baseline, 0),
+            raids=max(curr_raids - raids_baseline, 0),
+        )
+
+    if skipped:
+        log(INFO, f"{skipped}/{len(cur_by_uuid)} members skipped: no activity snapshot yet this membership",
+            context="vanity_roles")
     return out
 
 # --- NEW: tier helpers returning 't1'/'t2'/'t3' (or None) ---
@@ -258,12 +245,18 @@ class VanityRoles(commands.Cog):
             log(WARN, f"Contribution bucket role not found: '{BUCKET_ROLE_NAME}'", context="vanity_roles")
 
         grants = 0
+        unresolved: List[int] = []
         for section in ("wars", "raids"):
             for tier in ("t3", "t2", "t1"):
                 role = resolved[section][tier]
                 for did in winners_ids[section][tier]:
                     member = await self._get_member_anyhow(guild, did)
                     if member is None:
+                        # Earned a tier but their linked Discord account isn't in the
+                        # server (left, deleted, or a stale discord_links row). Silently
+                        # dropping these is why "X didn't get their role" reports were
+                        # impossible to tell apart from a scoring bug.
+                        unresolved.append(did)
                         continue
 
                     # Build exactly what we need to add (role + bucket if missing)
@@ -286,6 +279,9 @@ class VanityRoles(commands.Cog):
                             await asyncio.sleep(1.0)
                     except Exception as e:
                         log(ERROR, f"assign: add_roles failed for {member.id}: {e}", context="vanity_roles")
+        if unresolved:
+            log(WARN, f"assign: {len(unresolved)} winner(s) not found in the server: "
+                      f"{sorted(set(unresolved))}", context="vanity_roles")
         log(INFO, f"assign: granted roles to ~{grants} members", context="vanity_roles")
         return grants
 
@@ -340,9 +336,13 @@ class VanityRoles(commands.Cog):
                 "wars": {"t1": [], "t2": [], "t3": []},
                 "raids": {"t1": [], "t2": [], "t3": []},
             }
+            unlinked: List[str] = []
             for uuid, stats in stats_by_uuid.items():
                 did = uuid_to_discord.get(uuid)
                 if not did:
+                    # Would have earned a tier but has no discord_links row to award to.
+                    if _war_tier_label(stats.wars) or _raid_tier_label(stats.raids):
+                        unlinked.append(uuid)
                     continue
                 wtier = _war_tier_label(stats.wars)
                 if wtier:
@@ -350,6 +350,10 @@ class VanityRoles(commands.Cog):
                 rtier = _raid_tier_label(stats.raids)
                 if rtier:
                     winners_ids["raids"][rtier].append(did)
+
+            if unlinked:
+                log(WARN, f"{len(unlinked)} member(s) earned a tier but have no Discord link: {unlinked}",
+                    context="vanity_roles")
 
             # 5) Assign winners using resolved Role objects
             await self._assign_roles_to_winners(guild, winners_ids, resolved)

--- a/tests/test_vanity_windowed_stats.py
+++ b/tests/test_vanity_windowed_stats.py
@@ -1,0 +1,133 @@
+"""
+Test suite for Tasks/vanity_roles.py::compute_windowed_stats.
+
+Regression cover for members who joined inside the scoring window. The task used to
+run its own baseline lookup that returned None whenever a member had no snapshot
+from exactly `window_days` ago, and skipped those members outright — so every recent
+joiner was silently excluded from vanity roles no matter how much they contributed.
+
+Tests:
+1. A member who joined mid-window is scored from their first post-join snapshot
+2. An established member's delta is unchanged by the fix
+3. A member with no snapshot yet this membership is skipped, not given a 0 baseline
+4. A returning member is not credited progress from a previous membership
+"""
+
+import datetime
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Tasks import vanity_roles
+from Tasks.vanity_roles import compute_windowed_stats, _war_tier_label, _raid_tier_label
+
+WINDOW = 14
+NEWBIE = "11111111-1111-1111-1111-111111111111"
+VETERAN = "22222222-2222-2222-2222-222222222222"
+TODAY_JOIN = "33333333-3333-3333-3333-333333333333"
+RETURNEE = "44444444-4444-4444-4444-444444444444"
+
+
+def _member(uuid, name, joined, wars, raids):
+    return {"uuid": uuid, "name": name, "joined": joined, "wars": wars, "raids": raids}
+
+
+@pytest.fixture
+def guild_data():
+    return {
+        "time": 0,
+        "members": [
+            # joined 12 days ago, well inside the 14-day window
+            _member(NEWBIE, "Newbie", "2026-07-21T11:26:53.830000Z", 2248, 150),
+            # long-standing member
+            _member(VETERAN, "Veteran", "2026-03-27T00:32:40.234000Z", 1213, 40),
+            # joined today, snapshot job has not covered them yet
+            _member(TODAY_JOIN, "FreshFish", "2026-08-02T09:00:00.000000Z", 5000, 300),
+            # left and rejoined 5 days ago
+            _member(RETURNEE, "Returnee", "2026-07-28T00:00:00.000000Z", 900, 60),
+        ],
+    }
+
+
+@pytest.fixture
+def patched_db(guild_data):
+    """Patch the three Helpers.database calls compute_windowed_stats makes."""
+    baselines = {
+        # first snapshot after joining (2026-07-22) — everything since counts
+        "wars": {NEWBIE: (2032, True), VETERAN: (1170, False), RETURNEE: (860, True)},
+        "raids": {NEWBIE: (12, True), VETERAN: (40, False), RETURNEE: (55, True)},
+    }
+    # TODAY_JOIN has no snapshot inside its membership period
+    measurable = {NEWBIE, VETERAN, RETURNEE}
+
+    with patch.object(vanity_roles, "DB") as db_cls, \
+         patch.object(vanity_roles, "get_current_guild_data_with_db", return_value=guild_data), \
+         patch.object(vanity_roles, "get_members_with_baseline_history_with_db", return_value=measurable), \
+         patch.object(vanity_roles, "get_player_activity_baselines_for_members_with_db",
+                      side_effect=lambda db, key, days, joined: baselines[key]):
+        yield db_cls
+
+
+def test_mid_window_joiner_is_scored_not_skipped(patched_db):
+    stats = compute_windowed_stats(WINDOW)
+    assert NEWBIE in stats, "member who joined inside the window must still be scored"
+    assert stats[NEWBIE].wars == 2248 - 2032
+    assert stats[NEWBIE].raids == 150 - 12
+    assert _war_tier_label(stats[NEWBIE].wars) == "t3"
+    assert _raid_tier_label(stats[NEWBIE].raids) == "t3"
+
+
+def test_established_member_delta_unchanged(patched_db):
+    stats = compute_windowed_stats(WINDOW)
+    assert stats[VETERAN].wars == 1213 - 1170
+    assert stats[VETERAN].raids == 0
+    assert _war_tier_label(stats[VETERAN].wars) == "t1"
+    assert _raid_tier_label(stats[VETERAN].raids) is None
+
+
+def test_member_without_any_snapshot_is_skipped(patched_db):
+    """A 0 baseline on `wars` (a lifetime-cumulative counter) would hand someone
+    who joined hours ago their entire career total, and with it an instant t3."""
+    stats = compute_windowed_stats(WINDOW)
+    assert TODAY_JOIN not in stats
+
+
+def test_returning_member_not_credited_previous_membership(patched_db):
+    stats = compute_windowed_stats(WINDOW)
+    assert stats[RETURNEE].wars == 900 - 860
+    assert stats[RETURNEE].raids == 60 - 55
+
+
+def test_deltas_never_go_negative(patched_db, guild_data):
+    """A baseline above the live value (API blip, carried-forward row) must clamp to 0."""
+    guild_data["members"][1]["wars"] = 1000  # below the 1170 baseline
+    stats = compute_windowed_stats(WINDOW)
+    assert stats[VETERAN].wars == 0
+
+
+def test_private_profile_null_stats_treated_as_zero(patched_db, guild_data):
+    guild_data["members"][0]["wars"] = None
+    stats = compute_windowed_stats(WINDOW)
+    assert stats[NEWBIE].wars == 0
+    assert stats[NEWBIE].raids == 150 - 12  # raids still scored
+
+
+def test_empty_guild_data_returns_empty(patched_db, guild_data):
+    guild_data["members"] = []
+    assert compute_windowed_stats(WINDOW) == {}
+
+
+@pytest.mark.parametrize("wars,expected", [(39, None), (40, "t1"), (79, "t1"), (80, "t2"),
+                                           (119, "t2"), (120, "t3"), (500, "t3")])
+def test_war_tier_boundaries(wars, expected):
+    assert _war_tier_label(wars) == expected
+
+
+@pytest.mark.parametrize("raids,expected", [(29, None), (30, "t1"), (49, "t1"), (50, "t2"),
+                                            (79, "t2"), (80, "t3"), (200, "t3")])
+def test_raid_tier_boundaries(raids, expected):
+    assert _raid_tier_label(raids) == expected


### PR DESCRIPTION
## Problem

Members who joined within the last two weeks were never awarded vanity roles, regardless of how much they contributed. Reported for T3 Raids/T3 Wars (Leusteal) and T2 Raids (MoooseBoi).

`Tasks/vanity_roles.py` kept its own baseline lookup rather than using the shared helpers in `Helpers/database.py`. It resolved the 14th-most-recent snapshot date and required a row on *exactly* that date:

```python
if joined_date is not None and target_date < joined_date:
    return None          # every member who joined inside the window
...
if base_wars is None or base_raids is None:
    continue             # dropped from scoring entirely
```

Anyone who joined more recently than the baseline date has no snapshot there, so they were skipped outright — not scored as zero, just excluded. **17 of 148 members** on the 2026-08-02 run:

> Leusteal, MoooseBoi, uPig, Halev07, leter24, Starmin1234, Awesometurtle619, Sloptrix, Fine3ss, philyyy, WoolH, Emeralution, WhoCares31, btb_Rebel, cinanoe, qozmet, Zeturial

`Helpers/database.py` already handles this correctly, falling back to the member's earliest snapshot inside the current membership period. That's why `/activity` and `/leaderboard` displayed these members' numbers fine while their roles never appeared — the two paths disagreed.

## Fix

Delete the private lookup and use the shared batched helpers. Also drops the query count from two per member to one per key.

Adds `get_members_with_baseline_history_with_db`. The existing helpers return `(0, True)` both for "no snapshot at all" and for a legitimate zero. Callers turning a baseline into a delta on a lifetime-cumulative column need to tell those apart: a 0 baseline on `wars` would credit someone who joined hours ago their entire career total and hand them an instant T3. Members with no snapshot yet this membership are skipped instead.

## Verification

Run against production data (read-only):

| Member | Baseline | Before | After |
|---|---|---|---|
| Leusteal | first snapshot 2026-07-22 | *skipped* | wars 216 → **T3**, raids 138 → **T3** |
| MoooseBoi | first snapshot 2026-07-22 | *skipped* | wars 148 → **T3**, raids 68 → **T2** |

`compute_windowed_stats` now returns 148/148 members instead of 131. Established members' deltas are unchanged (spot-checked `_SlyGuy_`: 1213 − 1170 = 43 → T1 both before and after).

## Observability

Winners who earn a tier but can't be awarded it are now logged — no `discord_links` row, or a linked account no longer in the server. Both paths used to `continue` silently, which made "X didn't get their role" reports impossible to distinguish from a scoring bug.

This matters for the third report in this batch: **Lava / `_SlyGuy_` was not affected by this bug.** He has full snapshot history and scores correctly at 43 wars (just over the T1 threshold of 40), having only crossed it recently — on the 2026-07-26 run he was at 11, legitimately below T1. If he's still missing T1 Wars after the next run, these logs will say why. Separately, he has no `uncollected_raids` row at all, so his raid count is permanently 0 and he can never earn raid tiers.

## Tests

`tests/test_vanity_windowed_stats.py` — 21 new tests covering mid-window joiners, established members, the no-data guard, returning members not being credited a previous stint, negative-delta clamping, private profiles, and tier boundaries.

125 tests pass. The 3 collection errors in `test_annihilation_parties` / `test_background_*` are pre-existing (a `discord.ui` version mismatch) and fail on a clean checkout too.

## Not addressed

The job isn't actually bi-weekly. The gate is `(today - START_DATE).days % 7 != 0` while the class docstring says `% 14 == 0`, so it runs weekly with a 14-day lookback and windows overlap by 7 days. Left as-is — looks like a deliberate change the docs didn't follow, but worth confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
