### PR TITLE
fix: correct shell audit log wording for remove operations

### DIFF
--- a/Commands/manage.py
+++ b/Commands/manage.py
@@ -223,7 +223,9 @@ def _build_shells_card(user_id, ign, operation, amount, actor_name, actor_id):
         try:
             db.cursor.execute(
                 "INSERT INTO audit_log (log_type, actor_name, actor_id, action) VALUES (%s, %s, %s, %s)",
-                ('shell', actor_name, actor_id, f'{operation}ed {amount} to {player.username}.')
+                ('shell', actor_name, actor_id,
+                 f'added {amount} to {player.username}.' if operation == 'add'
+                 else f'removed {amount} from {player.username}.')
             )
             db.connection.commit()
         except Exception as e:


### PR DESCRIPTION
## Summary

Shell audit log entries for removals read `removeed 15 to Leusteal.` — a double bug in the message built at `Commands/manage.py`:

- `{operation}ed` concatenation produced **removeed** (`remove` + `ed`)
- **to** was hardcoded for both directions, so removals read "to" instead of "from"

Replaced the concatenation with explicit strings: `added {amount} to {name}.` / `removed {amount} from {name}.`

## Data cleanup

The 188 existing malformed `audit_log` rows in prod were already fixed in place with a transactional `regexp_replace` (`removeed {n} to ` → `removed {n} from `, trailing text preserved). No migration needed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)