### PR TITLE
fix: escape markdown in usernames sent to Discord

### DIFF
--- a/Commands/aspects.py
+++ b/Commands/aspects.py
@@ -287,7 +287,7 @@ class AspectDistribution(commands.Cog):
                     skipped += 1
                     continue
                 total += count
-                lines.append(f"{name}: {count}")
+                lines.append(f"{discord.utils.escape_markdown(name)}: {count}")
 
             if skipped:
                 log(INFO, f"Hid {skipped} departed member(s) from aspect queue", context="aspects")
@@ -330,7 +330,7 @@ class AspectDistribution(commands.Cog):
             if not aspect_db.add_to_blacklist(db, uuid, ctx.author.id):
                 return await ctx.followup.send("✅ Already blacklisted.")
             
-            await ctx.followup.send(f"✅ Added **{user.display_name}** to the aspect blacklist.")
+            await ctx.followup.send(f"✅ Added **{discord.utils.escape_markdown(user.display_name)}** to the aspect blacklist.")
 
         finally:
             db.close()
@@ -354,7 +354,7 @@ class AspectDistribution(commands.Cog):
             if not aspect_db.remove_from_blacklist(db, uuid):
                 return await ctx.followup.send("✅ User wasn't on the aspect blacklist.")
             
-            await ctx.followup.send(f"✅ Removed **{user.display_name}** from the aspect blacklist.")
+            await ctx.followup.send(f"✅ Removed **{discord.utils.escape_markdown(user.display_name)}** from the aspect blacklist.")
 
         finally:
             db.close()
@@ -388,7 +388,7 @@ class AspectDistribution(commands.Cog):
                 member = next((m for m in guild.all_members if m["uuid"] == uuid), None)
                 name = member["name"] if member else uuid[:8]
                 prefix = "→ " if i == 0 else "  "
-                lines.append(f"{prefix}{i+1}. {name}")
+                lines.append(f"{prefix}{i+1}. {discord.utils.escape_markdown(name)}")
             
             description = "\n".join(lines)
             description += f"\n\n**Total in queue:** {len(queue)}"

--- a/Commands/graidevent.py
+++ b/Commands/graidevent.py
@@ -406,7 +406,7 @@ def build_reward_rows(
 def _mention(row: dict) -> str:
     if row.get("discord_id"):
         return f"<@{row['discord_id']}>"
-    return f"**{row.get('display_name') or row.get('uuid', '')[:8]}**"
+    return f"**{discord.utils.escape_markdown(row.get('display_name') or row.get('uuid', '')[:8])}**"
 
 
 def _reward_line(row: dict) -> str:
@@ -681,7 +681,7 @@ class GraidEvent(commands.Cog):
             db.connection.commit()
 
             lines = [
-                f"`{row['placement']:>2}.` **{row['display_name']}** - {_format_points(row['ranking_points'])} points"
+                f"`{row['placement']:>2}.` **{discord.utils.escape_markdown(row['display_name'])}** - {_format_points(row['ranking_points'])} points"
                 for row in rows[:10]
             ]
             desc = "\n".join(lines) if lines else "_No qualifying participants._"
@@ -707,7 +707,7 @@ class GraidEvent(commands.Cog):
 
             rows = _load_reward_rows(cur, event, include_below_threshold=True)
             lines = [
-                f"`{row['placement']:>2}.` **{row['display_name']}** - {_format_points(row['ranking_points'])} points"
+                f"`{row['placement']:>2}.` **{discord.utils.escape_markdown(row['display_name'])}** - {_format_points(row['ranking_points'])} points"
                 for row in rows[:5]
             ]
             desc = "\n".join(lines) if lines else "_No one on the board yet._"

--- a/Commands/graidlog.py
+++ b/Commands/graidlog.py
@@ -195,7 +195,7 @@ class GraidCommands(commands.Cog):
             await channel.send(embed=embed)
 
         await ctx.followup.send(
-            f":white_check_mark: Logged **{raid_type}** raid with {', '.join(players)}",
+            f":white_check_mark: Logged **{raid_type}** raid with {', '.join(discord.utils.escape_markdown(p) for p in players)}",
             ephemeral=True,
         )
 
@@ -258,7 +258,7 @@ class GraidCommands(commands.Cog):
                 name = display_names.get(key, key)
                 type_parts = [f"{t}:{data[t]}" for t in ["NOTG", "TCC", "TNA", "NOL", "WTP"] if data[t] > 0]
                 type_str = f" ({', '.join(type_parts)})" if type_parts else ""
-                lines.append(f"`{i:>2}.` **{name}** — {data['total']}{type_str}")
+                lines.append(f"`{i:>2}.` **{discord.utils.escape_markdown(name)}** — {data['total']}{type_str}")
 
             embed = discord.Embed(
                 title="Guild Raid Leaderboard",
@@ -307,7 +307,7 @@ class GraidCommands(commands.Cog):
 
             rows = cur.fetchall()
             if not rows:
-                await ctx.followup.send(f"No guild raid logs found for **{ign}**.", ephemeral=True)
+                await ctx.followup.send(f"No guild raid logs found for **{discord.utils.escape_markdown(ign)}**.", ephemeral=True)
                 return
 
             total = len(rows)
@@ -348,13 +348,13 @@ class GraidCommands(commands.Cog):
 
             type_lines = [f"**{t}**: {c}" for t, c in type_counts.most_common()]
             embed = discord.Embed(
-                title=f"Guild Raid Stats: {ign}",
+                title=f"Guild Raid Stats: {discord.utils.escape_markdown(ign)}",
                 description=f"**{total}** total raids",
                 color=0x3474EB,
             )
             embed.add_field(name="Raid Types", value="\n".join(type_lines) or "—", inline=True)
 
-            tm_lines = [f"{tm}: {c}" for tm, c in teammates.most_common(5)]
+            tm_lines = [f"{discord.utils.escape_markdown(tm)}: {c}" for tm, c in teammates.most_common(5)]
             embed.add_field(name="Top Teammates", value="\n".join(tm_lines) or "—", inline=True)
             embed.add_field(name="Best Day", value=f"{best_day} ({best_day_count} raids)", inline=False)
 
@@ -486,7 +486,7 @@ class GraidCommands(commands.Cog):
                 top_with_offsets.append((name, total))
             top_with_offsets.sort(key=lambda x: -x[1])
 
-            top_lines = [f"`{i+1}.` **{name}** — {total}" for i, (name, total) in enumerate(top_with_offsets[:5])]
+            top_lines = [f"`{i+1}.` **{discord.utils.escape_markdown(name)}** — {total}" for i, (name, total) in enumerate(top_with_offsets[:5])]
 
             embed = discord.Embed(title="Guild Raid Overview", color=0x3474EB)
             embed.add_field(name="Summary", value=f"**{total_raids}** raids by **{unique_players}** players", inline=False)

--- a/Commands/kick_list.py
+++ b/Commands/kick_list.py
@@ -38,7 +38,7 @@ class KickList(commands.Cog):
 
         result = await asyncio.to_thread(getPlayerUUID, ign)
         if not result:
-            await ctx.followup.send(f"Could not find player **{ign}**.", ephemeral=True)
+            await ctx.followup.send(f"Could not find player **{discord.utils.escape_markdown(ign)}**.", ephemeral=True)
             return
 
         username, uuid = result
@@ -55,7 +55,7 @@ class KickList(commands.Cog):
         await asyncio.to_thread(_add_to_kick_list_sync, uuid, username, tier, added_by)
         priority = {1: "High", 2: "Medium", 3: "Low"}[tier]
         await ctx.followup.send(
-            f"Added **{username}** to the kick list ({priority} Priority).", ephemeral=True
+            f"Added **{discord.utils.escape_markdown(username)}** to the kick list ({priority} Priority).", ephemeral=True
         )
 
         await refresh_kick_list_message(self.client)
@@ -71,12 +71,12 @@ class KickList(commands.Cog):
         removed = await asyncio.to_thread(_remove_from_kick_list_sync, ign)
         if not removed:
             await ctx.followup.send(
-                f"**{ign}** was not found on the kick list.", ephemeral=True
+                f"**{discord.utils.escape_markdown(ign)}** was not found on the kick list.", ephemeral=True
             )
             return
 
         await ctx.followup.send(
-            f"Removed **{ign}** from the kick list.", ephemeral=True
+            f"Removed **{discord.utils.escape_markdown(ign)}** from the kick list.", ephemeral=True
         )
 
         await refresh_kick_list_message(self.client)

--- a/Commands/manage.py
+++ b/Commands/manage.py
@@ -408,7 +408,7 @@ class Manage(commands.Cog):
             # Previously getPlayerUUID(ign)[1] crashed with TypeError on a
             # failed lookup; fail with a clear message instead.
             await ctx.followup.send(
-                f':no_entry: Could not resolve **{ign}** — check the spelling and try again.',
+                f':no_entry: Could not resolve **{discord.utils.escape_markdown(ign)}** — check the spelling and try again.',
                 ephemeral=True
             )
         elif result == 'updated':
@@ -418,12 +418,12 @@ class Manage(commands.Cog):
             except:
                 pass
             await ctx.followup.send(
-                f'Updated link for **{user.name}** to **{ign}**',
+                f'Updated link for **{discord.utils.escape_markdown(user.name)}** to **{discord.utils.escape_markdown(ign)}**',
                 ephemeral=True
             )
         else:
             await ctx.followup.send(
-                f'Linked **{user.name}** to **{ign}**',
+                f'Linked **{discord.utils.escape_markdown(user.name)}** to **{discord.utils.escape_markdown(ign)}**',
                 ephemeral=True
             )
 

--- a/Commands/progress.py
+++ b/Commands/progress.py
@@ -44,7 +44,7 @@ class Progress(commands.Cog):
         max_overall = max_lvl + max_discovery + max_quests + max_dungeons + max_raids
         if not playerdata:
             embed = discord.Embed(title=':no_entry: Something went wrong',
-                                  description=f'Could not find a player with name **{name}**!', color=0xe33232)
+                                  description=f'Could not find a player with name **{discord.utils.escape_markdown(name)}**!', color=0xe33232)
             await message.respond(embed=embed, ephemeral=True)
             return
         all_classes = []

--- a/Commands/register.py
+++ b/Commands/register.py
@@ -91,7 +91,7 @@ class Register(commands.Cog):
         await asyncio.to_thread(self._upsert_ally_link, user.id, canonical_ign, uuid, rank)
 
         await ctx.followup.send(
-            f'Registered {user.mention} as **{rank} {canonical_ign}** for **{guild}**.',
+            f'Registered {user.mention} as **{rank} {discord.utils.escape_markdown(canonical_ign)}** for **{guild}**.',
             ephemeral=True,
         )
 

--- a/Commands/snipe.py
+++ b/Commands/snipe.py
@@ -1022,7 +1022,8 @@ def _format_participants_log(pairs: list[tuple[str, str]]) -> str:
     parts = []
     for role in _ROLE_ORDER:
         if role in grouped:
-            parts.append(f"{' '.join(grouped[role])} {role}")
+            names = ' '.join(discord.utils.escape_markdown(ign) for ign in grouped[role])
+            parts.append(f"{names} {role}")
     return ' / '.join(parts)
 
 

--- a/Commands/top_wars.py
+++ b/Commands/top_wars.py
@@ -174,7 +174,7 @@ class ConfirmView(discord.ui.View):
             for winner in self.winners:
                 discord_id = winner.get('discord_id')
                 if not discord_id:
-                    failed.append(f"{winner['name']} (no Discord link)")
+                    failed.append(f"{discord.utils.escape_markdown(winner['name'])} (no Discord link)")
                     continue
 
                 db.cursor.execute('SELECT balance FROM shells WHERE "user" = %s', (discord_id,))

--- a/Tasks/annihilation_parties.py
+++ b/Tasks/annihilation_parties.py
@@ -329,7 +329,7 @@ class StaffMemberPickerView(discord.ui.View):
             return
 
         await interaction.response.edit_message(
-            content=f"Remove **{member['ign']}** from Party {member['party_number']}?",
+            content=f"Remove **{discord.utils.escape_markdown(member['ign'])}** from Party {member['party_number']}?",
             view=ConfirmRemovalView(
                 self.cog,
                 self.invoker_id,
@@ -978,7 +978,7 @@ class AnnihilationParties(commands.Cog):
         self._forget_event(event_id)
         self._schedule_board_refresh(event_id)
         await interaction.followup.send(
-            f"Removed **{removed['ign']}** from Party {removed['party_number']}",
+            f"Removed **{discord.utils.escape_markdown(removed['ign'])}** from Party {removed['party_number']}",
             ephemeral=True,
         )
 

--- a/Tasks/check_apps.py
+++ b/Tasks/check_apps.py
@@ -116,7 +116,7 @@ class CheckApps(commands.Cog):
                 if getattr(thread, "archived", False):
                     await thread.edit(archived=False)
                 await thread.send(
-                    f"{APP_MANAGER_ROLE_MENTION} **{ign}** has left their guild! "
+                    f"{APP_MANAGER_ROLE_MENTION} **{discord.utils.escape_markdown(ign)}** has left their guild! "
                     f"They can now be invited.\n"
                     f"Run `/app invited` in the ticket channel or this thread to send them the invite message."
                 )

--- a/Tasks/check_website_apps.py
+++ b/Tasks/check_website_apps.py
@@ -384,7 +384,7 @@ class CheckWebsiteApps(commands.Cog):
                     filename = f"{channel_label}-{pdata.UUID}.png"
                     player_info_file = discord.File(buf, filename=filename)
                     poll_embed.set_image(url=f"attachment://{filename}")
-                    poll_embed.title = f"Application {channel_label} ({pdata.username})"
+                    poll_embed.title = f"Application {channel_label} ({discord.utils.escape_markdown(pdata.username)})"
 
                     # Check blacklist
                     blacklist = get_blacklist()
@@ -392,7 +392,7 @@ class CheckWebsiteApps(commands.Cog):
                         if pdata.UUID == player["UUID"]:
                             desc = (
                                 f":no_entry: Player present on blacklist!\n"
-                                f"**Name:** {pdata.username}\n**UUID:** {pdata.UUID}"
+                                f"**Name:** {discord.utils.escape_markdown(pdata.username)}\n**UUID:** {pdata.UUID}"
                             )
                             if player.get("reason"):
                                 desc += f"\n**Reason:** {player['reason']}"
@@ -428,7 +428,7 @@ class CheckWebsiteApps(commands.Cog):
 
         # Post the application content in the thread
         stats_line = f"<https://wynncraft.com/stats/player/{ign}>\n" if ign else ""
-        thread_header = f"**Application from {mention} ({discord_username}):**\n{stats_line}\n"
+        thread_header = f"**Application from {mention} ({discord.utils.escape_markdown(discord_username)}):**\n{stats_line}\n"
         thread_combined = f"{thread_header}{formatted}"
         if len(thread_combined) <= 2000:
             await thread.send(thread_combined)
@@ -490,12 +490,12 @@ class CheckWebsiteApps(commands.Cog):
         for i, desc in enumerate(embeds_data):
             part_label = f"(Part {i + 1}/{total_parts})" if total_parts > 1 else ""
             embed = discord.Embed(
-                title=f"Hammerhead Application - {ign} {part_label}",
+                title=f"Hammerhead Application - {discord.utils.escape_markdown(ign)} {part_label}",
                 description=desc,
                 colour=0x04B0EB,  # Hammerhead rank colour
             )
             if i == 0:
-                embed.add_field(name="Applicant", value=f"{mention} ({discord_username})", inline=True)
+                embed.add_field(name="Applicant", value=f"{mention} ({discord.utils.escape_markdown(discord_username)})", inline=True)
                 embed.add_field(name="Type", value="Hammerhead", inline=True)
             if i == total_parts - 1:
                 embed.add_field(name="Status", value=":green_circle: Received", inline=True)

--- a/Tasks/promotion_queue_processor.py
+++ b/Tasks/promotion_queue_processor.py
@@ -420,12 +420,12 @@ class PromotionQueueProcessor(commands.Cog):
             title="Promotion Queue - Processing Failed",
             color=0xe33232,
         )
-        embed.add_field(name="IGN", value=entry['ign'], inline=True)
+        embed.add_field(name="IGN", value=discord.utils.escape_markdown(entry['ign']), inline=True)
         embed.add_field(name="Action", value=entry['action_type'], inline=True)
         embed.add_field(name="New Rank", value=entry.get('new_rank') or "N/A", inline=True)
         embed.add_field(
             name="Queued By",
-            value=f"<@{entry['queued_by_discord_id']}> ({entry['queued_by_ign']})",
+            value=f"<@{entry['queued_by_discord_id']}> ({discord.utils.escape_markdown(entry['queued_by_ign'])})",
             inline=False,
         )
         embed.add_field(name="Error", value=f"```{error_msg[:900]}```", inline=False)
@@ -451,14 +451,15 @@ class PromotionQueueProcessor(commands.Cog):
         if successes:
             lines = []
             for ign, action_type, new_rank in successes:
+                safe_ign = discord.utils.escape_markdown(ign)
                 if new_rank:
-                    lines.append(f"**{ign}**: {action_type} -> **{new_rank}**")
+                    lines.append(f"**{safe_ign}**: {action_type} -> **{new_rank}**")
                 else:
-                    lines.append(f"**{ign}**: {action_type}")
+                    lines.append(f"**{safe_ign}**: {action_type}")
             embed.add_field(name="Completed", value="\n".join(lines)[:1024], inline=False)
 
         if failures:
-            lines = [f"**{ign}** ({action_type}): {err[:100]}" for ign, action_type, err in failures]
+            lines = [f"**{discord.utils.escape_markdown(ign)}** ({action_type}): {err[:100]}" for ign, action_type, err in failures]
             embed.add_field(name="Failed", value="\n".join(lines)[:1024], inline=False)
 
         await promo_ch.send(embed=embed)

--- a/Tasks/territory_tracker.py
+++ b/Tasks/territory_tracker.py
@@ -423,8 +423,8 @@ class TerritoryTracker(commands.Cog):
 
                         # get the guild that took the territory and build message
                         if lost_terr:
-                            attacker = new_data.get(lost_terr, {}).get("guild", {}).get("name", "Unknown")
-                            attacker_prefix = new_data.get(lost_terr, {}).get("guild", {}).get("prefix", "???")
+                            attacker = discord.utils.escape_markdown(new_data.get(lost_terr, {}).get("guild", {}).get("name", "Unknown"))
+                            attacker_prefix = discord.utils.escape_markdown(new_data.get(lost_terr, {}).get("guild", {}).get("prefix", "???"))
                             if should_ping_spearhead:
                                 mention = f"<@&{SPEARHEAD_ROLE_ID}>"
                                 msg = f"{mention} **Attack on {claim_name}!** {terr_type.capitalize()} **{lost_terr}** taken by **{attacker} [{attacker_prefix}]**"
@@ -506,7 +506,7 @@ class TerritoryTracker(commands.Cog):
                             # Send congratulations message to military channel (no ping)
                             alert_chan = self.client.get_channel(MILITARY_CHANNEL_ID)
                             if alert_chan:
-                                congrats_msg = f"🎉 Congratulations on a successful snipe of **{claim_name}** owned by **{old['owner']}**!"
+                                congrats_msg = f"🎉 Congratulations on a successful snipe of **{claim_name}** owned by **{discord.utils.escape_markdown(old['owner'])}**!"
                                 await alert_chan.send(congrats_msg)
                         elif DEBUG_HQ_CONGRATS:
                             log(INFO,


### PR DESCRIPTION
## Summary

Usernames containing underscores (e.g. `_example_`) rendered italic in bot-created lists — reported in the snipe log, but the same bug existed anywhere a name was interpolated into Discord-rendered text.

Applied `discord.utils.escape_markdown` (the pattern already used in `update_member_data.py` and `graidlog.py`'s raid-log embed) at every remaining site where a player/guild name lands in message content, embed descriptions/fields, or titles:

- **snipe.py** — `_format_participants_log` (covers preview embed, success embed, and the snipe-log channel post)
- **graidlog.py** — logged confirmation, leaderboard, stats title, top teammates, top players
- **graidevent.py** — `_mention` fallback + both event leaderboards
- **kick_list.py, manage.py, aspects.py, progress.py, register.py, top_wars.py** — confirmations, errors, queue listings
- **Tasks/** — promotion queue embeds, application embeds/threads (`check_website_apps`, `check_apps`), annihilation party prompts, territory tracker alerts (guild names, same bug class)

## Not changed (already safe)

- Names drawn onto image cards (PIL) — images don't render markdown
- Names wrapped in inline code backticks
- `scripts/backfill_graid_logs.py` already unescapes this exact character set when parsing old messages, so escaped names round-trip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)