### PR TITLE
Prevent linking one Minecraft uuid to multiple Discord accounts

### DIFF
--- a/Commands/app_commands.py
+++ b/Commands/app_commands.py
@@ -16,6 +16,7 @@ from Helpers.app_transcript import (
 from Helpers.database import DB
 from Helpers.embed_updater import update_web_poll_embed
 from Helpers.functions import generate_applicant_info, getPlayerUUID, getPlayerDatav3
+from Helpers.links import LinkConflictError, assert_row_linkable, assert_uuid_free
 from Helpers.openai_helper import parse_recruiter_source, match_recruiter_name
 from Helpers.sheets import add_row
 from Helpers.variables import (
@@ -195,13 +196,17 @@ class WebAppCommands(commands.Cog):
             )
 
             # Link and mark as linked immediately
+            link_conflict = None
             if ign and uuid:
-                await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=False)
+                try:
+                    await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=False)
+                except LinkConflictError as e:
+                    link_conflict = e
 
             # Trigger auto-registration directly
             from Tasks.update_member_data import UpdateMemberData
             cog = self.client.get_cog("UpdateMemberData")
-            if cog and uuid:
+            if cog and uuid and not link_conflict:
                 try:
                     await cog._auto_register_joined_member(uuid, ign)
                 except Exception as e:
@@ -209,7 +214,10 @@ class WebAppCommands(commands.Cog):
                     log(LOG_ERROR, f"Immediate registration failed for {ign}: {e}", context="app_commands")
 
             await update_web_poll_embed(self.client, channel.id, ":orange_circle: Registered", 0xFFE019)
-            feedback = f"Application accepted. IGN: `{ign}`. Player was already in TAq — registered immediately."
+            if link_conflict:
+                feedback = f"Application accepted, but NOT registered: {link_conflict.user_message()}"
+            else:
+                feedback = f"Application accepted. IGN: `{ign}`. Player was already in TAq — registered immediately."
 
         elif in_guild:
             await channel.send(
@@ -224,7 +232,10 @@ class WebAppCommands(commands.Cog):
             )
 
             if ign and uuid:
-                await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=False)
+                try:
+                    await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=False)
+                except LinkConflictError as e:
+                    await ctx.followup.send(e.user_message(), ephemeral=True)
 
             await update_web_poll_embed(self.client, channel.id, ":yellow_circle: Accepted - Pending Leave", 0xFFE019)
             feedback = (
@@ -243,7 +254,10 @@ class WebAppCommands(commands.Cog):
             )
 
             if ign and uuid:
-                await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=False)
+                try:
+                    await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=False)
+                except LinkConflictError as e:
+                    await ctx.followup.send(e.user_message(), ephemeral=True)
 
             guild = self.client.get_guild(channel.guild.id) or channel.guild
             invited_cat = discord.utils.get(guild.categories, name=INVITED_CATEGORY_NAME)
@@ -292,7 +306,10 @@ class WebAppCommands(commands.Cog):
             uuid_data = await asyncio.to_thread(getPlayerUUID, ign)
             uuid = uuid_data[1] if uuid_data else None
             if uuid:
-                await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=True)
+                try:
+                    await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=True)
+                except LinkConflictError as e:
+                    await ctx.followup.send(e.user_message(), ephemeral=True)
             if applicant:
                 try:
                     await applicant.edit(nick=ign)
@@ -494,7 +511,12 @@ class WebAppCommands(commands.Cog):
         await channel.send("This application acceptance has been rescinded.")
 
         # Update DB status to denied
-        await asyncio.to_thread(self._db_rescind, app["id"])
+        link_conflict = await asyncio.to_thread(self._db_rescind, app["id"])
+        if link_conflict:
+            await ctx.followup.send(
+                f"Rescinded, but the member row was not re-linked: {link_conflict.user_message()}",
+                ephemeral=True,
+            )
 
         # Update poll embed
         await update_web_poll_embed(self.client, channel.id,
@@ -602,13 +624,20 @@ class WebAppCommands(commands.Cog):
                 (app_id,)
             )
             row = db.cursor.fetchone()
+            conflict = None
             if row:
-                db.cursor.execute(
-                    """UPDATE discord_links SET linked = TRUE
-                       WHERE discord_id = %s AND linked = FALSE""",
-                    (int(row[0]),)
-                )
+                try:
+                    assert_row_linkable(db.cursor, int(row[0]))
+                    db.cursor.execute(
+                        """UPDATE discord_links SET linked = TRUE
+                           WHERE discord_id = %s AND linked = FALSE""",
+                        (int(row[0]),)
+                    )
+                except LinkConflictError as e:
+                    # Still record the denial; only the relink is blocked.
+                    conflict = e
             db.connection.commit()
+            return conflict
         finally:
             db.close()
 
@@ -616,6 +645,9 @@ class WebAppCommands(commands.Cog):
     def _link_discord(discord_id, ign, uuid, app_channel, linked=False):
         db = DB(); db.connect()
         try:
+            # Guard even the linked=False writes: a row seeded with another
+            # member's uuid gets flipped to linked later (rescind/auto-register).
+            assert_uuid_free(db.cursor, uuid, discord_id)
             db.cursor.execute(
                 """INSERT INTO discord_links (discord_id, ign, uuid, linked, rank, app_channel)
                    VALUES (%s, %s, %s, %s, '', %s)

--- a/Commands/app_commands.py
+++ b/Commands/app_commands.py
@@ -213,10 +213,11 @@ class WebAppCommands(commands.Cog):
                     from Helpers.logger import log, ERROR as LOG_ERROR
                     log(LOG_ERROR, f"Immediate registration failed for {ign}: {e}", context="app_commands")
 
-            await update_web_poll_embed(self.client, channel.id, ":orange_circle: Registered", 0xFFE019)
             if link_conflict:
+                await update_web_poll_embed(self.client, channel.id, ":red_circle: Link Conflict", 0xE33232)
                 feedback = f"Application accepted, but NOT registered: {link_conflict.user_message()}"
             else:
+                await update_web_poll_embed(self.client, channel.id, ":orange_circle: Registered", 0xFFE019)
                 feedback = f"Application accepted. IGN: `{ign}`. Player was already in TAq — registered immediately."
 
         elif in_guild:

--- a/Commands/manage.py
+++ b/Commands/manage.py
@@ -12,6 +12,7 @@ from PIL import Image, ImageDraw, ImageFont, ImageOps
 
 from Helpers.classes import LinkAccount, PlayerStats, PlayerShells
 from Helpers.database import DB
+from Helpers.links import LinkConflictError, assert_uuid_free
 from Helpers.functions import addLine, split_sentence, expand_image, getPlayerUUID, timed_get
 from Helpers.logger import log, ERROR
 from Helpers.variables import HOME_GUILD_IDS, discord_ranks, discord_rank_roles
@@ -122,6 +123,7 @@ def _link_user(user_id, ign, base_nick):
 
     db = DB(); db.connect()
     try:
+        assert_uuid_free(db.cursor, uuid, user_id)
         db.cursor.execute(
             "SELECT * FROM discord_links WHERE discord_id = %s", (user_id,)
         )
@@ -402,7 +404,11 @@ class Manage(commands.Cog):
     ):
         await ctx.defer(ephemeral=True)
         base = (user.nick.split(' ')[0] if user.nick else '')
-        result = await asyncio.to_thread(_link_user, user.id, ign, base)
+        try:
+            result = await asyncio.to_thread(_link_user, user.id, ign, base)
+        except LinkConflictError as e:
+            await ctx.followup.send(e.user_message(), ephemeral=True)
+            return
 
         if result is None:
             # Previously getPlayerUUID(ign)[1] crashed with TypeError on a

--- a/Commands/new_member.py
+++ b/Commands/new_member.py
@@ -8,6 +8,7 @@ from discord import default_permissions
 from Helpers.classes import LinkAccount, PlayerStats, BasicPlayerStats
 from Helpers.database import DB
 from Helpers.functions import getPlayerUUID, determine_starting_rank
+from Helpers.links import LinkConflictError, assert_uuid_free
 from Helpers.variables import HOME_GUILD_IDS, discord_ranks
 
 
@@ -21,6 +22,8 @@ def _fetch_new_member_data(user_id, ign):
     try:
         db.cursor.execute('SELECT * FROM discord_links WHERE discord_id = %s', (user_id,))
         rows = db.cursor.fetchall()
+        if not pdata.error:
+            assert_uuid_free(db.cursor, pdata.UUID, user_id)
     finally:
         db.close()
 
@@ -36,7 +39,11 @@ class NewMember(commands.Cog):
     async def new_member(self, message, user: discord.Member, ign):
         if message.interaction.user.guild_permissions.manage_roles:
             await message.defer(ephemeral=True)
-            rows, pdata = await asyncio.to_thread(_fetch_new_member_data, user.id, ign)
+            try:
+                rows, pdata = await asyncio.to_thread(_fetch_new_member_data, user.id, ign)
+            except LinkConflictError as e:
+                await message.respond(e.user_message(), ephemeral=True)
+                return
             if pdata.error:
                 embed = discord.Embed(title=':no_entry: Oops! Something did not go as intended.',
                                       description=f'Could not retrieve information of `{ign}`.\nPlease check your spelling or try again later.',

--- a/Commands/register.py
+++ b/Commands/register.py
@@ -6,6 +6,7 @@ from discord.ext import commands
 
 from Helpers.database import DB
 from Helpers.functions import getPlayerUUID
+from Helpers.links import LinkConflictError, assert_uuid_free
 from Helpers.variables import HOME_GUILD_IDS
 
 
@@ -68,6 +69,12 @@ class Register(commands.Cog):
         rank = ally_config['rank']
 
         try:
+            await asyncio.to_thread(self._check_link_conflict, user.id, uuid)
+        except LinkConflictError as e:
+            await ctx.followup.send(e.user_message(), ephemeral=True)
+            return
+
+        try:
             if ally_role not in user.roles:
                 await user.add_roles(
                     ally_role,
@@ -88,7 +95,11 @@ class Register(commands.Cog):
             )
             return
 
-        await asyncio.to_thread(self._upsert_ally_link, user.id, canonical_ign, uuid, rank)
+        try:
+            await asyncio.to_thread(self._upsert_ally_link, user.id, canonical_ign, uuid, rank)
+        except LinkConflictError as e:
+            await ctx.followup.send(e.user_message(), ephemeral=True)
+            return
 
         await ctx.followup.send(
             f'Registered {user.mention} as **{rank} {discord.utils.escape_markdown(canonical_ign)}** for **{guild}**.',
@@ -96,10 +107,21 @@ class Register(commands.Cog):
         )
 
     @staticmethod
+    def _check_link_conflict(discord_id: int, uuid: str):
+        """Blocking DB read — call via asyncio.to_thread."""
+        db = DB()
+        db.connect()
+        try:
+            assert_uuid_free(db.cursor, uuid, discord_id)
+        finally:
+            db.close()
+
+    @staticmethod
     def _upsert_ally_link(discord_id: int, ign: str, uuid: str, rank: str):
         db = DB()
         db.connect()
         try:
+            assert_uuid_free(db.cursor, uuid, discord_id)
             db.cursor.execute(
                 """INSERT INTO discord_links (discord_id, ign, uuid, linked, rank)
                    VALUES (%s, %s, %s, TRUE, %s)

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -507,6 +507,7 @@ class NewMember(Modal):
                 await msg.edit(content=e.user_message(), embed=None)
                 return
         if pdata.error:
+            db.close()
             embed = discord.Embed(title=':no_entry: Oops! Something did not go as intended.',
                                   description=f'Could not retrieve information of `{self.children[0].value}`.\nPlease check your spelling or try again later.',
                                   color=0xe33232)

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -13,6 +13,7 @@ from Helpers.database import (
     get_player_activity_baselines_with_db,
 )
 from Helpers.functions import getPlayerUUID, getPlayerDatav3, getPlayerProfileDatav3, urlify, determine_starting_rank, timed_get
+from Helpers.links import LinkConflictError, assert_uuid_free
 from discord.ext.pages import Page as _Page
 
 from Helpers.variables import wynn_ranks, WELCOME_CHANNEL_ID, discord_ranks
@@ -498,6 +499,13 @@ class NewMember(Modal):
         db.cursor.execute('SELECT * FROM discord_links WHERE discord_id = %s', (self.user.id,))
         rows = db.cursor.fetchall()
         pdata = BasicPlayerStats(self.children[0].value)
+        if not pdata.error:
+            try:
+                assert_uuid_free(db.cursor, pdata.UUID, self.user.id)
+            except LinkConflictError as e:
+                db.close()
+                await msg.edit(content=e.user_message(), embed=None)
+                return
         if pdata.error:
             embed = discord.Embed(title=':no_entry: Oops! Something did not go as intended.',
                                   description=f'Could not retrieve information of `{self.children[0].value}`.\nPlease check your spelling or try again later.',

--- a/Helpers/links.py
+++ b/Helpers/links.py
@@ -1,0 +1,67 @@
+"""Guards for discord_links writes.
+
+A Minecraft account may be linked to at most one Discord account at a time.
+The database enforces this with the partial unique index
+discord_links_linked_uuid_uq (schema.sql); duplicate linked rows fan out every
+uuid join in the bot and website, duplicating leaderboard rows and
+double-counting raid points. These helpers let write paths detect the conflict
+up front and report it to the invoker instead of failing on the constraint.
+
+Unlinked historical rows (e.g. a member who left) may still share a uuid with
+a live link — only currently-linked rows are protected.
+"""
+
+
+class LinkConflictError(Exception):
+    """Raised when a uuid is already linked to a different Discord account."""
+
+    def __init__(self, uuid, other_discord_id, other_ign):
+        self.uuid = uuid
+        self.other_discord_id = other_discord_id
+        self.other_ign = other_ign
+        super().__init__(
+            f"Minecraft account {other_ign} ({uuid}) is already linked to "
+            f"Discord account {other_discord_id}"
+        )
+
+    def user_message(self):
+        """Standard operator-facing explanation for command responses."""
+        return (
+            f":no_entry: **{self.other_ign}** is already linked to "
+            f"<@{self.other_discord_id}>. Unlink that account first "
+            f"(or remove the stale row) before linking it elsewhere."
+        )
+
+
+def find_linked_uuid_conflict(cursor, uuid, discord_id):
+    """Return (discord_id, ign) of a *different* Discord account currently
+    linked to this uuid, or None."""
+    if not uuid:
+        return None
+    cursor.execute(
+        "SELECT discord_id, ign FROM discord_links"
+        " WHERE uuid = %s AND linked = TRUE AND discord_id <> %s"
+        " LIMIT 1",
+        (uuid, discord_id),
+    )
+    return cursor.fetchone()
+
+
+def assert_uuid_free(cursor, uuid, discord_id):
+    """Raise LinkConflictError if uuid is linked to a different Discord account."""
+    conflict = find_linked_uuid_conflict(cursor, uuid, discord_id)
+    if conflict:
+        raise LinkConflictError(uuid, conflict[0], conflict[1])
+
+
+def assert_row_linkable(cursor, discord_id):
+    """Guard for paths that flip an existing row to linked = TRUE without
+    touching its uuid: raise LinkConflictError if that row's uuid is already
+    linked to a different Discord account."""
+    cursor.execute(
+        "SELECT uuid FROM discord_links WHERE discord_id = %s",
+        (discord_id,),
+    )
+    row = cursor.fetchone()
+    if row and row[0]:
+        assert_uuid_free(cursor, row[0], discord_id)

--- a/Tasks/process_website_decisions.py
+++ b/Tasks/process_website_decisions.py
@@ -10,6 +10,7 @@ from Helpers.logger import log, INFO, ERROR
 from Helpers.database import DB
 from Helpers.embed_updater import update_web_poll_embed, update_hammerhead_poll_embed
 from Helpers.functions import getPlayerDatav3, getPlayerUUID
+from Helpers.links import LinkConflictError, assert_uuid_free
 from Helpers.variables import TAQ_GUILD_ID, INVITED_CATEGORY_NAME
 
 
@@ -184,12 +185,13 @@ class ProcessWebsiteDecisions(commands.Cog):
             else:
                 await channel.send(msg_text)
 
+            linked_ok = True
             if ign and uuid:
-                await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=False)
+                linked_ok = await self._link_or_report(channel, link_id, ign, uuid, linked=False)
 
             # Trigger immediate registration (same pattern as app_commands.py)
             cog = self.client.get_cog("UpdateMemberData")
-            if cog and uuid:
+            if cog and uuid and linked_ok:
                 try:
                     await cog._auto_register_joined_member(uuid, ign)
                 except Exception as e:
@@ -219,7 +221,7 @@ class ProcessWebsiteDecisions(commands.Cog):
                 await channel.send(msg_text)
 
             if ign and uuid:
-                await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=False)
+                await self._link_or_report(channel, link_id, ign, uuid, linked=False)
 
             await update_web_poll_embed(self.client, channel.id,
                                         ":yellow_circle: Accepted - Pending Leave", 0xFFE019)
@@ -243,7 +245,7 @@ class ProcessWebsiteDecisions(commands.Cog):
                 await channel.send(msg_text)
 
             if ign and uuid:
-                await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=False)
+                await self._link_or_report(channel, link_id, ign, uuid, linked=False)
 
             guild_obj = self.client.get_guild(channel.guild.id) or channel.guild
             invited_cat = discord.utils.get(guild_obj.categories, name=INVITED_CATEGORY_NAME)
@@ -301,7 +303,7 @@ class ProcessWebsiteDecisions(commands.Cog):
             uuid_data = await asyncio.to_thread(getPlayerUUID, ign)
             uuid = uuid_data[1] if uuid_data else None
             if uuid:
-                await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=True)
+                await self._link_or_report(channel, link_id, ign, uuid, linked=True)
             if applicant:
                 try:
                     await applicant.edit(nick=ign)
@@ -433,6 +435,9 @@ class ProcessWebsiteDecisions(commands.Cog):
         db = DB()
         db.connect()
         try:
+            # Guard even the linked=False writes: a row seeded with another
+            # member's uuid gets flipped to linked later (rescind/auto-register).
+            assert_uuid_free(db.cursor, uuid, discord_id)
             db.cursor.execute(
                 """INSERT INTO discord_links (discord_id, ign, uuid, linked, rank, app_channel)
                    VALUES (%s, %s, %s, %s, '', %s)
@@ -445,6 +450,17 @@ class ProcessWebsiteDecisions(commands.Cog):
             db.connection.commit()
         finally:
             db.close()
+
+    async def _link_or_report(self, channel, link_id, ign, uuid, linked):
+        """Link, or report a uuid conflict in the app channel.
+        Returns True when the link was written."""
+        try:
+            await asyncio.to_thread(self._link_discord, link_id, ign, uuid, channel.id, linked=linked)
+            return True
+        except LinkConflictError as e:
+            log(ERROR, f"Link conflict for {ign}: {e}", context="process_website_decisions")
+            await channel.send(f":warning: {e.user_message()}")
+            return False
 
     @staticmethod
     def _db_set_guild_leave(app_id, guild_leave_pending):

--- a/Tasks/process_website_decisions.py
+++ b/Tasks/process_website_decisions.py
@@ -198,8 +198,12 @@ class ProcessWebsiteDecisions(commands.Cog):
                     log(ERROR, f"Immediate registration failed for {ign}: {e}",
                         context="process_website_decisions")
 
-            await update_web_poll_embed(self.client, channel.id,
-                                        ":orange_circle: Registered", 0xFFE019)
+            if linked_ok:
+                await update_web_poll_embed(self.client, channel.id,
+                                            ":orange_circle: Registered", 0xFFE019)
+            else:
+                await update_web_poll_embed(self.client, channel.id,
+                                            ":red_circle: Link Conflict", 0xE33232)
             await asyncio.to_thread(self._db_set_guild_leave, app_id, False)
 
         elif in_guild:

--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -26,6 +26,7 @@ from Helpers.logger import log, INFO, WARN, ERROR
 from Helpers.classes import Guild, DB, BasicPlayerStats
 from Helpers.embed_updater import update_web_poll_embed
 from Helpers.functions import getPlayerDatav3, getNameFromUUID, determine_starting_rank, create_progress_bar, addLine, round_corners
+from Helpers.links import LinkConflictError, assert_row_linkable
 from Helpers.variables import (
     RAID_LOG_CHANNEL_ID,
     BOT_LOG_CHANNEL_ID,
@@ -965,6 +966,7 @@ class UpdateMemberData(commands.Cog):
             db = DB()
             try:
                 db.connect()
+                assert_row_linkable(db.cursor, did)
                 db.cursor.execute(
                     """UPDATE discord_links
                        SET linked = TRUE, rank = %s, ign = %s, wars_on_join = %s
@@ -981,7 +983,11 @@ class UpdateMemberData(commands.Cog):
             finally:
                 db.close()
 
-        await asyncio.to_thread(_complete_registration, discord_id, ign, uuid, wars_on_join, starting_rank)
+        try:
+            await asyncio.to_thread(_complete_registration, discord_id, ign, uuid, wars_on_join, starting_rank)
+        except LinkConflictError as e:
+            log(ERROR, f"Registration link conflict for {ign}: {e}", context="auto_register")
+            return
 
         # Update poll embed
         if app_channel_id:

--- a/schema.sql
+++ b/schema.sql
@@ -11,6 +11,13 @@ CREATE TABLE IF NOT EXISTS discord_links (
   wars_on_join INT
 );
 
+-- A Minecraft account may be linked to at most one Discord account at a time.
+-- Duplicate linked rows fan out every uuid join (bot and website), duplicating
+-- leaderboard rows and double-counting raid points. Unlinked historical rows
+-- may still share a uuid (e.g. a member who left and relinked elsewhere).
+CREATE UNIQUE INDEX IF NOT EXISTS discord_links_linked_uuid_uq
+  ON discord_links (uuid) WHERE linked AND uuid IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS new_app (
   id                   SERIAL       PRIMARY KEY,
   channel              BIGINT       NOT NULL UNIQUE,

--- a/tests/test_link_guard.py
+++ b/tests/test_link_guard.py
@@ -1,0 +1,94 @@
+"""
+Test suite for the discord_links uuid guard (Helpers/links.py).
+
+A Minecraft uuid may be linked to at most one Discord account; these helpers
+back the partial unique index discord_links_linked_uuid_uq with up-front
+detection so commands can report the conflict instead of failing on the
+constraint.
+
+1. find_linked_uuid_conflict returns the other account's row when the uuid is
+   linked elsewhere, and None when it is free / owned by the same account
+2. A falsy uuid never queries and never conflicts
+3. assert_uuid_free raises LinkConflictError carrying the conflicting account
+4. assert_row_linkable checks the stored uuid of an existing row, and passes
+   for rows without a uuid
+5. user_message mentions the conflicting Discord account
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Helpers.links import (
+    LinkConflictError,
+    assert_row_linkable,
+    assert_uuid_free,
+    find_linked_uuid_conflict,
+)
+
+UUID = "065fc385-f9c1-4e7f-96b3-8674a65c509f"
+
+
+class FakeCursor:
+    """Replays queued fetchone results and records executed queries."""
+
+    def __init__(self, results):
+        self.results = list(results)
+        self.queries = []
+
+    def execute(self, sql, params=None):
+        self.queries.append((sql, params))
+
+    def fetchone(self):
+        return self.results.pop(0)
+
+
+def test_conflict_found():
+    cursor = FakeCursor([(500, "Kenji121")])
+    assert find_linked_uuid_conflict(cursor, UUID, 751) == (500, "Kenji121")
+    (sql, params), = cursor.queries
+    assert params == (UUID, 751)
+    assert "linked = TRUE" in sql
+
+
+def test_no_conflict():
+    cursor = FakeCursor([None])
+    assert find_linked_uuid_conflict(cursor, UUID, 751) is None
+
+
+def test_falsy_uuid_skips_query():
+    cursor = FakeCursor([])
+    assert find_linked_uuid_conflict(cursor, None, 751) is None
+    assert find_linked_uuid_conflict(cursor, "", 751) is None
+    assert cursor.queries == []
+
+
+def test_assert_uuid_free_raises_with_conflict_details():
+    cursor = FakeCursor([(500, "Kenji121")])
+    with pytest.raises(LinkConflictError) as excinfo:
+        assert_uuid_free(cursor, UUID, 751)
+    err = excinfo.value
+    assert err.uuid == UUID
+    assert err.other_discord_id == 500
+    assert err.other_ign == "Kenji121"
+    assert "<@500>" in err.user_message()
+
+
+def test_assert_uuid_free_passes_when_free():
+    assert_uuid_free(FakeCursor([None]), UUID, 751)
+
+
+def test_assert_row_linkable_conflict():
+    # First fetch: the row's stored uuid; second: the conflicting link.
+    cursor = FakeCursor([(UUID,), (500, "Kenji121")])
+    with pytest.raises(LinkConflictError):
+        assert_row_linkable(cursor, 751)
+
+
+def test_assert_row_linkable_free_and_uuidless():
+    assert_row_linkable(FakeCursor([(UUID,), None]), 751)
+    assert_row_linkable(FakeCursor([(None,)]), 751)
+    assert_row_linkable(FakeCursor([None]), 751)


### PR DESCRIPTION
## Problem

`discord_links` allows multiple rows to share a `uuid`, and several linking flows write a uuid without checking whether it is already linked to a different Discord account. Two members (Kenji121, _SlyGuy_) ended up with duplicate linked rows, which fanned out every `JOIN ... ON uuid` across the bot and website — duplicated "ghost" leaderboard rows and double-counted raid points. The duplicate rows have been cleaned up in prod (with a full-table backup taken first); this PR prevents recurrence.

## Changes

- **Schema**: partial unique index `discord_links_linked_uuid_uq ON discord_links(uuid) WHERE linked AND uuid IS NOT NULL` — the hard backstop. Already applied to prod and dev; `schema.sql` replay is idempotent. Unlinked historical rows may still share a uuid.
- **`Helpers/links.py`** (new): `assert_uuid_free` / `assert_row_linkable` raise `LinkConflictError` (with an operator-facing `user_message()`) when a uuid is already linked to a different account.
- Guarded every `discord_links` uuid write path:
  - `Commands/register.py` `/register ally` — checks before role/nick changes, replies with the conflicting account
  - `Commands/new_member.py` and the `NewMember` modal in `Helpers/classes.py` — same, before any role work
  - `Commands/manage.py` `_link_user` — refuses with the conflict message
  - `Commands/app_commands.py` `_link_discord` (all call sites) — guarded even for `linked=False` seeds, since rescind/auto-register flip them later; accept flows warn the exec and skip auto-registration
  - `Commands/app_commands.py` `_db_rescind` — still records the denial; only the relink is skipped, and the exec is told
  - `Tasks/process_website_decisions.py` — background task logs the conflict and posts a warning in the app channel
  - `Tasks/update_member_data.py` `_complete_registration` — logs and aborts before flipping `linked`

## Testing

- New `tests/test_link_guard.py` covering conflict/no-conflict, falsy-uuid short-circuit, and the row-linkable path
- Full suite: 165 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)