### PR TITLE
Replace graid queue mode with announce flag

### DIFF
--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -462,7 +462,7 @@ class UpdateMemberData(commands.Cog):
             db = _db_connect_with_retry()
             try:
                 db.cursor.execute("""
-                    SELECT id, raid_type, mode, participants
+                    SELECT id, raid_type, announce, participants
                     FROM graid_log_queue
                     WHERE status = 'pending'
                     ORDER BY created_at
@@ -483,7 +483,7 @@ class UpdateMemberData(commands.Cog):
 
         log(INFO, f"Processing {len(rows)} queued graid log(s)", context="graid_queue")
 
-        for queue_id, raid_type, mode, participants_data in rows:
+        for queue_id, raid_type, announce, participants_data in rows:
             try:
                 # JSONB columns come back as already-parsed objects from psycopg,
                 # but tolerate the string case just in case.
@@ -498,10 +498,10 @@ class UpdateMemberData(commands.Cog):
                 # 1. DB writes (graid_logs, participants, event totals, uncollected_raids).
                 await asyncio.to_thread(_graid_log_manual_sync, participants, raid_type)
 
-                # 2. Discord announcement — match the website's previous behavior:
-                # only post for full groups with a known raid type. Individual logs are
-                # silent (they're for fixing missed/desynced raids, not announcements).
-                if mode == 'group' and raid_type:
+                # 2. Discord announcement — only when requested and the raid type
+                # is known. Unknown-type raids are silent fix-ups for missed or
+                # desynced raids, whatever the party size.
+                if announce and raid_type:
                     names = [p['ign'] for p in participants]
                     await self._post_raid_announcement(raid_type, names, guild)
 
@@ -517,7 +517,7 @@ class UpdateMemberData(commands.Cog):
                     finally:
                         db.close()
                 await asyncio.to_thread(_mark_done, queue_id)
-                log(INFO, f"Processed queued graid log #{queue_id} ({raid_type or 'Unknown'}, {mode})", context="graid_queue")
+                log(INFO, f"Processed queued graid log #{queue_id} ({raid_type or 'Unknown'}, {'announced' if announce and raid_type else 'silent'})", context="graid_queue")
 
             except Exception as e:
                 log(ERROR, f"Failed to process queued graid log #{queue_id}: {e}", context="graid_queue")

--- a/schema.sql
+++ b/schema.sql
@@ -234,7 +234,7 @@ CREATE TABLE IF NOT EXISTS graid_raid_offsets (
 CREATE TABLE IF NOT EXISTS graid_log_queue (
   id               SERIAL      PRIMARY KEY,
   raid_type        VARCHAR(40),                 -- Full raid name, NULL = unknown
-  mode             VARCHAR(16) NOT NULL,        -- 'group' or 'individual'
+  announce         BOOLEAN     NOT NULL DEFAULT TRUE,  -- post to Discord (only honored for known raid types)
   participants     JSONB       NOT NULL,        -- [{uuid: "..."|null, ign: "..."}, ...]
   submitted_by     BIGINT,                      -- Discord ID of the submitter
   submitted_by_ign VARCHAR(64),
@@ -326,6 +326,16 @@ BEGIN
   -- applications: app_number column for persistent counter-based naming
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'applications' AND column_name = 'app_number') THEN
     ALTER TABLE applications ADD COLUMN app_number INT;
+  END IF;
+
+  -- graid_log_queue: the old mode column ('group'/'individual') is replaced by
+  -- the announce flag — party size no longer changes how a raid is processed.
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'graid_log_queue' AND column_name = 'announce') THEN
+    ALTER TABLE graid_log_queue ADD COLUMN announce BOOLEAN NOT NULL DEFAULT TRUE;
+    UPDATE graid_log_queue SET announce = (mode = 'group');
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'graid_log_queue' AND column_name = 'mode') THEN
+    ALTER TABLE graid_log_queue DROP COLUMN mode;
   END IF;
 END $$;
 

--- a/schema.sql
+++ b/schema.sql
@@ -332,7 +332,7 @@ BEGIN
   -- the announce flag — party size no longer changes how a raid is processed.
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'graid_log_queue' AND column_name = 'announce') THEN
     ALTER TABLE graid_log_queue ADD COLUMN announce BOOLEAN NOT NULL DEFAULT TRUE;
-    UPDATE graid_log_queue SET announce = (mode = 'group');
+    UPDATE graid_log_queue SET announce = COALESCE(mode = 'group', TRUE);
   END IF;
   IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'graid_log_queue' AND column_name = 'mode') THEN
     ALTER TABLE graid_log_queue DROP COLUMN mode;


### PR DESCRIPTION
## Problem

`graid_log_queue.mode` ('group'/'individual') predates 1–4-player raid logging. Party size no longer changes how a raid is processed — the only thing mode still encoded was whether the bot should post the raid to Discord, and the website was already deriving it from an `announce` boolean and converting back. Companion website PR: Thundderr/Tort-Reborn-Graid-Event-Website#18.

## Changes

- `graid_log_queue` now carries `announce BOOLEAN NOT NULL DEFAULT TRUE` instead of `mode`. The schema.sql migration block adds `announce` (backfilled `mode = 'group'`) and drops `mode`, idempotently.
- The queue drain in `Tasks/update_member_data.py` announces when `announce` is set and the raid type is known — Unknown-type raids stay silent regardless of party size.

## Deploy ordering

Prod already has the transitional state applied: `announce` added and backfilled, `mode` relaxed to nullable (the running bot still reads it). Merge/deploy this before the next prod `schema.sql` replay, which drops `mode`. During the window where the old bot processes new announce-only rows, `mode` is NULL, which fails the old `mode == 'group'` check — wrong direction is a missed announcement, never a wrong one. Dev DB is already fully migrated.

## Testing

- Full suite: 165 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)