### PR TITLE
Resolve missing participant uuids when draining the graid queue

### DIFF
--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -502,11 +502,12 @@ class UpdateMemberData(commands.Cog):
                 # the raids leaderboard.
                 for p in participants:
                     if not p.get('uuid'):
-                        pdata = await asyncio.to_thread(getPlayerUUID, p['ign'])
+                        ign = p.get('ign')
+                        pdata = await asyncio.to_thread(getPlayerUUID, ign) if ign else None
                         if pdata:
                             p['uuid'] = pdata[1]
                         else:
-                            log(WARN, f"Could not resolve uuid for '{p['ign']}' in queued graid log #{queue_id}; writing with NULL uuid", context="graid_queue")
+                            log(WARN, f"Could not resolve uuid for '{ign}' in queued graid log #{queue_id}; writing with NULL uuid", context="graid_queue")
 
                 # 1. DB writes (graid_logs, participants, event totals, uncollected_raids).
                 await asyncio.to_thread(_graid_log_manual_sync, participants, raid_type)

--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -25,7 +25,7 @@ else:
 from Helpers.logger import log, INFO, WARN, ERROR
 from Helpers.classes import Guild, DB, BasicPlayerStats
 from Helpers.embed_updater import update_web_poll_embed
-from Helpers.functions import getPlayerDatav3, getNameFromUUID, determine_starting_rank, create_progress_bar, addLine, round_corners
+from Helpers.functions import getPlayerDatav3, getNameFromUUID, getPlayerUUID, determine_starting_rank, create_progress_bar, addLine, round_corners
 from Helpers.links import LinkConflictError, assert_row_linkable
 from Helpers.variables import (
     RAID_LOG_CHANNEL_ID,
@@ -494,6 +494,19 @@ class UpdateMemberData(commands.Cog):
 
                 if not participants:
                     raise ValueError("queue row has no participants")
+
+                # A participant may be queued without a uuid (unlinked member,
+                # no discord_links row yet). The Minecraft identity is
+                # resolvable from the ign regardless — a NULL uuid row would be
+                # invisible to event leaderboards and duplicate the player on
+                # the raids leaderboard.
+                for p in participants:
+                    if not p.get('uuid'):
+                        pdata = await asyncio.to_thread(getPlayerUUID, p['ign'])
+                        if pdata:
+                            p['uuid'] = pdata[1]
+                        else:
+                            log(WARN, f"Could not resolve uuid for '{p['ign']}' in queued graid log #{queue_id}; writing with NULL uuid", context="graid_queue")
 
                 # 1. DB writes (graid_logs, participants, event totals, uncollected_raids).
                 await asyncio.to_thread(_graid_log_manual_sync, participants, raid_type)


### PR DESCRIPTION
## Problem

Manually-logged raids for players without a `discord_links` row were written to `graid_log_participants` with a NULL uuid. Those rows are invisible to event leaderboards (which filter `uuid IS NOT NULL`, silently dropping earned points) and produced phantom duplicate entries on the raids leaderboard (fixed on the read side in Thundderr/Tort-Reborn-Graid-Event-Website#19).

## Changes

- The queue drain in `Tasks/update_member_data.py` now resolves any participant with a missing uuid via `getPlayerUUID(ign)` (Mojang, Wynncraft fallback) before writing — a participant's identity is their Minecraft uuid, independent of Discord linkage. If resolution still fails, it logs a WARN and writes NULL as before, so an API outage degrades visibly instead of losing the raid.
- Resolution happens at drain time rather than in the website POST so every producer is covered in one place and no request handler grows an external API call.

Existing orphan rows have been backfilled directly (21 of 22 matched a linked `discord_links` row; the last has no link and no resolvable identity — full pre-change snapshot retained).

## Testing

- Full suite: 165 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)