### PR TITLE
fix: unstall auto-transcribe queue when poll_status regresses after close

### DIFF
--- a/Helpers/app_transcript.py
+++ b/Helpers/app_transcript.py
@@ -27,8 +27,8 @@ class TranscriptError(Exception):
 def classify_transcript_candidate(head, now, delay=AUTO_TRANSCRIBE_DELAY):
     """Decide what to do with the lowest un-transcribed ticket (`head`).
 
-    `head` is a dict with keys `poll_status`, `channel_id`, `effective_closed_at`,
-    or None when there is no un-transcribed ticket.
+    `head` is a dict with keys `poll_status`, `channel_id`, `closed_at`,
+    `effective_closed_at`, or None when there is no un-transcribed ticket.
 
     Returns:
         "none"       -- nothing to do
@@ -38,7 +38,15 @@ def classify_transcript_candidate(head, now, delay=AUTO_TRANSCRIBE_DELAY):
     """
     if head is None:
         return "none"
-    if head.get("poll_status") != CLOSED_POLL_STATUS:
+    # A ticket counts as closed if poll_status says so OR closed_at is stamped.
+    # closed_at is written once when the channel enters Closed Applications and
+    # never regresses, so it wins over poll_status, which later lifecycle writers
+    # (e.g. auto-registration finishing after the close) can clobber.
+    is_closed = (
+        head.get("poll_status") == CLOSED_POLL_STATUS
+        or head.get("closed_at") is not None
+    )
+    if not is_closed:
         return "wait"  # still open -> blocks higher tickets (strict order)
     if not head.get("channel_id"):
         return "skip"  # closed but nothing to transcribe

--- a/Helpers/embed_updater.py
+++ b/Helpers/embed_updater.py
@@ -1,8 +1,16 @@
 import asyncio
 
+from Helpers.app_transcript import CLOSED_POLL_STATUS
 from Helpers.database import DB
 from Helpers.poll_edit import safe_edit_poll
 from Helpers.variables import MEMBER_APP_CHANNEL_ID, HAMMERHEAD_APP_CHANNEL_ID
+
+
+def is_poll_status_downgrade(current_status, new_status):
+    """Closed is terminal: never regress a closed ticket to an earlier lifecycle
+    state (e.g. auto-registration completing after the ticket was closed). A
+    regressed poll_status stalls the auto-transcribe queue. Pure."""
+    return current_status == CLOSED_POLL_STATUS and new_status != CLOSED_POLL_STATUS
 
 
 async def update_web_poll_embed(client, channel_id: int, new_status: str, colour: int):
@@ -13,10 +21,11 @@ async def update_web_poll_embed(client, channel_id: int, new_status: str, colour
         try:
             db.connect()
             db.cursor.execute(
-                "SELECT id, poll_message_id FROM applications WHERE channel_id = %s", (cid,)
+                "SELECT id, poll_message_id, poll_status FROM applications WHERE channel_id = %s",
+                (cid,),
             )
             row = db.cursor.fetchone()
-            return (row[0], row[1]) if row else (None, None)
+            return (row[0], row[1], row[2]) if row else (None, None, None)
         finally:
             db.close()
 
@@ -50,7 +59,9 @@ async def update_web_poll_embed(client, channel_id: int, new_status: str, colour
         finally:
             db.close()
 
-    app_id, poll_message_id = await asyncio.to_thread(_fetch_poll_data, channel_id)
+    app_id, poll_message_id, current_status = await asyncio.to_thread(_fetch_poll_data, channel_id)
+    if is_poll_status_downgrade(current_status, new_status):
+        return
     if not poll_message_id:
         return
 

--- a/Helpers/embed_updater.py
+++ b/Helpers/embed_updater.py
@@ -30,13 +30,21 @@ async def update_web_poll_embed(client, channel_id: int, new_status: str, colour
             db.close()
 
     def _update_db_status(cid, status):
+        """Atomic form of the downgrade guard: the pre-read check above is
+        advisory only (another call can close the ticket between the read and
+        this write), so the UPDATE itself refuses to regress a Closed ticket.
+        Returns True when the row was actually updated."""
         db = DB()
         try:
             db.connect()
             db.cursor.execute(
-                "UPDATE applications SET poll_status = %s WHERE channel_id = %s", (status, cid)
+                "UPDATE applications SET poll_status = %s "
+                "WHERE channel_id = %s AND NOT (poll_status = %s AND %s <> %s)",
+                (status, cid, CLOSED_POLL_STATUS, status, CLOSED_POLL_STATUS),
             )
+            updated = db.cursor.rowcount > 0
             db.connection.commit()
+            return updated
         finally:
             db.close()
 
@@ -94,7 +102,8 @@ async def update_web_poll_embed(client, channel_id: int, new_status: str, colour
                 if not found_votes:
                     embed.add_field(name="Votes", value=vote_text, inline=False)
 
-    await asyncio.to_thread(_update_db_status, channel_id, new_status)
+    if not await asyncio.to_thread(_update_db_status, channel_id, new_status):
+        return
     await safe_edit_poll(exec_chan, poll_message_id, modify_embed=_modify, include_view=False)
 
 

--- a/Tasks/check_apps.py
+++ b/Tasks/check_apps.py
@@ -259,7 +259,7 @@ class CheckApps(commands.Cog):
         try:
             db.cursor.execute(
                 """SELECT id, app_number, application_type, discord_id, discord_username,
-                          status, answers, poll_status, channel_id,
+                          status, answers, poll_status, channel_id, closed_at,
                           COALESCE(closed_at, reviewed_at) AS effective_closed_at
                      FROM applications
                     WHERE application_type IN ('guild', 'community')
@@ -276,7 +276,7 @@ class CheckApps(commands.Cog):
             return None
 
         (app_id, app_number, application_type, discord_id, discord_username,
-         status, answers, poll_status, channel_id, effective_closed_at) = row
+         status, answers, poll_status, channel_id, closed_at, effective_closed_at) = row
         if isinstance(answers, str):
             answers = json.loads(answers)
         return {
@@ -289,6 +289,7 @@ class CheckApps(commands.Cog):
             "answers": answers or {},
             "poll_status": poll_status,
             "channel_id": channel_id,
+            "closed_at": closed_at,
             "effective_closed_at": effective_closed_at,
         }
 

--- a/tests/test_app_transcript.py
+++ b/tests/test_app_transcript.py
@@ -14,6 +14,7 @@ def _head(**overrides):
     base = {
         "poll_status": CLOSED_POLL_STATUS,
         "channel_id": 123,
+        "closed_at": NOW - datetime.timedelta(days=4),
         "effective_closed_at": NOW - datetime.timedelta(days=4),
     }
     base.update(overrides)
@@ -25,7 +26,41 @@ def test_none_when_no_head():
 
 
 def test_wait_when_head_still_open():
-    assert classify_transcript_candidate(_head(poll_status=":green_circle: Received"), NOW) == "wait"
+    head = _head(poll_status=":green_circle: Received", closed_at=None, effective_closed_at=None)
+    assert classify_transcript_candidate(head, NOW) == "wait"
+
+
+def test_transcribe_when_closed_at_set_despite_stale_poll_status():
+    # Regression: auto-registration completing after close overwrote poll_status
+    # (Closed -> Registered) and stalled the queue. closed_at is stamped once and
+    # never regresses, so it wins over poll_status.
+    head = _head(poll_status=":orange_circle: Registered")
+    assert classify_transcript_candidate(head, NOW) == "transcribe"
+
+
+def test_skip_when_closed_at_set_stale_poll_status_and_no_channel():
+    head = _head(poll_status=":orange_circle: Registered", channel_id=None)
+    assert classify_transcript_candidate(head, NOW) == "skip"
+
+
+def test_wait_when_closed_at_set_but_delay_not_elapsed():
+    head = _head(
+        poll_status=":orange_circle: Registered",
+        closed_at=NOW - datetime.timedelta(days=2),
+        effective_closed_at=NOW - datetime.timedelta(days=2),
+    )
+    assert classify_transcript_candidate(head, NOW) == "wait"
+
+
+def test_wait_when_reviewed_but_not_closed():
+    # reviewed_at feeds effective_closed_at via COALESCE; a reviewed-but-open
+    # ticket (no closed_at, poll_status not Closed) must still wait.
+    head = _head(
+        poll_status=":orange_circle: Accepted",
+        closed_at=None,
+        effective_closed_at=NOW - datetime.timedelta(days=10),
+    )
+    assert classify_transcript_candidate(head, NOW) == "wait"
 
 
 def test_skip_when_no_channel():

--- a/tests/test_app_transcript.py
+++ b/tests/test_app_transcript.py
@@ -14,10 +14,14 @@ def _head(**overrides):
     base = {
         "poll_status": CLOSED_POLL_STATUS,
         "channel_id": 123,
-        "closed_at": NOW - datetime.timedelta(days=4),
         "effective_closed_at": NOW - datetime.timedelta(days=4),
     }
     base.update(overrides)
+    # Mirror _fetch_transcript_head: effective_closed_at is
+    # COALESCE(closed_at, reviewed_at), so closed_at tracks the effective
+    # timestamp unless a test explicitly decouples them (reviewed-but-open).
+    if "closed_at" not in overrides:
+        base["closed_at"] = base["effective_closed_at"]
     return base
 
 

--- a/tests/test_embed_updater.py
+++ b/tests/test_embed_updater.py
@@ -1,0 +1,22 @@
+from Helpers.app_transcript import CLOSED_POLL_STATUS
+from Helpers.embed_updater import is_poll_status_downgrade
+
+
+def test_downgrade_from_closed_is_blocked():
+    assert is_poll_status_downgrade(CLOSED_POLL_STATUS, ":orange_circle: Registered") is True
+
+
+def test_closing_is_allowed():
+    assert is_poll_status_downgrade(":orange_circle: Registered", CLOSED_POLL_STATUS) is False
+
+
+def test_closed_to_closed_is_allowed():
+    assert is_poll_status_downgrade(CLOSED_POLL_STATUS, CLOSED_POLL_STATUS) is False
+
+
+def test_normal_lifecycle_transition_is_allowed():
+    assert is_poll_status_downgrade(":green_circle: Received", ":orange_circle: Accepted") is False
+
+
+def test_missing_current_status_is_allowed():
+    assert is_poll_status_downgrade(None, ":orange_circle: Registered") is False


### PR DESCRIPTION
## Problem

Prod app #3880 sat un-transcribed for days and, because the auto-transcribe queue is strict head-of-line, blocked every closed ticket behind it (10 fully-ready tickets at time of writing).

Root cause: the ticket was closed (`closed_at` stamped, `poll_status = Closed`) before the applicant had joined the in-game guild. When they joined later, the auto-registration flow's `update_web_poll_embed(..., "Registered")` unconditionally overwrote `poll_status`, and `classify_transcript_candidate` returns `wait` for any head whose `poll_status` isn't Closed — forever. App #3748 shows the same historical signature, so this is a recurring race, not a one-off.

## Fix (both sides)

- **Reader:** `classify_transcript_candidate` now treats a ticket as closed when `closed_at` is stamped, regardless of `poll_status`. `closed_at` is written once when the channel enters Closed Applications and never regresses, so it's the reliable signal. `_fetch_transcript_head` feeds the raw `closed_at` through alongside the existing `effective_closed_at` (which COALESCEs `reviewed_at` and therefore can't be used for this check — a reviewed-but-open ticket must still wait).
- **Writer:** `update_web_poll_embed` refuses to downgrade a Closed ticket to an earlier lifecycle state (new pure `is_poll_status_downgrade` guard). Closed is terminal; every other status passed by callers is a pre-close state, so no legitimate transition is blocked.

## Tests

- Classifier: stale `poll_status` + stamped `closed_at` → `transcribe` (and `skip` when the channel is gone); reviewed-but-open ticket still waits; delay gating unchanged.
- Guard: downgrade blocked, closing/re-closing/normal lifecycle transitions allowed.
- Full suite: 174 passed.

Note: app #3880 itself still needs its row corrected once (`poll_status` back to Closed) or it will simply transcribe on the next tick after this deploys — the reader fix handles it without any data surgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)