### PR TITLE
Keep discord_links.ign fresh and stop using names as player identity

### DIFF
--- a/Commands/graidlog.py
+++ b/Commands/graidlog.py
@@ -116,6 +116,11 @@ class GraidCommands(commands.Cog):
             for m in current_members
             if m.get('name') or m.get('username')
         }
+        uuid_by_name = {
+            (m.get('name') or m.get('username') or '').casefold(): m.get('uuid')
+            for m in current_members
+            if m.get('name') or m.get('username')
+        }
 
         if not current_names:
             await ctx.followup.send(':no_entry: Guild member data unavailable. Try again later.', ephemeral=True)
@@ -154,28 +159,35 @@ class GraidCommands(commands.Cog):
             )
             log_id = cur.fetchone()[0]
 
+            # Identity comes from the live guild data the players were just
+            # validated against — discord_links.ign can lag a rename, and a
+            # missed uuid here silently costs the player event points and payout.
+            uuids = {}
             for ign in players:
-                cur.execute("SELECT uuid FROM discord_links WHERE LOWER(ign) = LOWER(%s)", (ign,))
-                uuid_row = cur.fetchone()
-                uuid_val = uuid_row[0] if uuid_row else None
+                uuid_val = uuid_by_name.get(ign.casefold())
+                if not uuid_val:
+                    cur.execute("SELECT uuid FROM discord_links WHERE LOWER(ign) = LOWER(%s)", (ign,))
+                    uuid_row = cur.fetchone()
+                    uuid_val = uuid_row[0] if uuid_row else None
+                uuids[ign] = uuid_val
+
+            for ign in players:
                 cur.execute(
                     "INSERT INTO graid_log_participants (log_id, uuid, ign) VALUES (%s, %s, %s)",
-                    (log_id, uuid_val, ign)
+                    (log_id, uuids[ign], ign)
                 )
 
             # Upsert totals if event is active
             if event_id is not None:
                 for ign in players:
-                    cur.execute("SELECT uuid FROM discord_links WHERE LOWER(ign) = LOWER(%s)", (ign,))
-                    uuid_row = cur.fetchone()
-                    if uuid_row and uuid_row[0]:
+                    if uuids[ign]:
                         cur.execute("""
                             INSERT INTO graid_event_totals (event_id, uuid, total)
                             VALUES (%s, %s, 1)
                             ON CONFLICT (event_id, uuid) DO UPDATE
                               SET total = graid_event_totals.total + 1,
                                   last_updated = NOW()
-                        """, (event_id, uuid_row[0]))
+                        """, (event_id, uuids[ign]))
 
             db.connection.commit()
         finally:
@@ -194,8 +206,13 @@ class GraidCommands(commands.Cog):
             )
             await channel.send(embed=embed)
 
+        unresolved = [p for p in players if not uuids.get(p)]
+        warning = (
+            f"\n:warning: No uuid resolved for {', '.join(f'`{p}`' for p in unresolved)} — "
+            f"logged without event credit; link the account and re-check."
+        ) if unresolved else ""
         await ctx.followup.send(
-            f":white_check_mark: Logged **{raid_type}** raid with {', '.join(discord.utils.escape_markdown(p) for p in players)}",
+            f":white_check_mark: Logged **{raid_type}** raid with {', '.join(discord.utils.escape_markdown(p) for p in players)}{warning}",
             ephemeral=True,
         )
 

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timezone
 import json
 import os
@@ -469,16 +470,33 @@ class LinkAccount(Modal):
         self.add_item(InputText(label="Player's Name", placeholder="Player's In-Game Name without rank"))
 
     async def callback(self, interaction: discord.Interaction):
+        # Resolve the Minecraft uuid up front — a row without one is invisible
+        # to every uuid-keyed join (shells snapshot, raid credit, profiles).
+        ign = self.children[0].value
+        player_data = await asyncio.to_thread(getPlayerUUID, ign)
+        uuid = player_data[1] if player_data else None
+        canonical_ign = player_data[0] if player_data else ign
+
         db = DB()
         db.connect()
-        db.cursor.execute(
-            'INSERT INTO discord_links (discord_id, ign, linked, rank) VALUES (%s, %s, %s, %s)',
-            (self.user.id, self.children[0].value, False, self.rank)
-        )
-        db.connection.commit()
-        await self.user.edit(nick=f"{self.rank} {self.children[0].value}")
-        await interaction.response.send_message(f'{self.added}\n\n{self.removed}', ephemeral=True)
-        db.close()
+        try:
+            if uuid:
+                assert_uuid_free(db.cursor, uuid, self.user.id)
+            db.cursor.execute(
+                'INSERT INTO discord_links (discord_id, ign, uuid, linked, rank) VALUES (%s, %s, %s, %s, %s)',
+                (self.user.id, canonical_ign, uuid, False, self.rank)
+            )
+            db.connection.commit()
+        except LinkConflictError as e:
+            await interaction.response.send_message(e.user_message(), ephemeral=True)
+            return
+        finally:
+            db.close()
+        await self.user.edit(nick=f"{self.rank} {canonical_ign}")
+        message = f'{self.added}\n\n{self.removed}'
+        if not uuid:
+            message += f"\n\n:warning: Could not resolve a Minecraft account for `{ign}` — linked without a uuid; re-link once the name is confirmed."
+        await interaction.response.send_message(message, ephemeral=True)
 
 
 class NewMember(Modal):

--- a/Helpers/classes.py
+++ b/Helpers/classes.py
@@ -470,6 +470,10 @@ class LinkAccount(Modal):
         self.add_item(InputText(label="Player's Name", placeholder="Player's In-Game Name without rank"))
 
     async def callback(self, interaction: discord.Interaction):
+        # The uuid lookup is HTTP and can outlast Discord's 3s initial response
+        # window — defer first, respond via followups only.
+        await interaction.response.defer(ephemeral=True)
+
         # Resolve the Minecraft uuid up front — a row without one is invisible
         # to every uuid-keyed join (shells snapshot, raid credit, profiles).
         ign = self.children[0].value
@@ -488,15 +492,18 @@ class LinkAccount(Modal):
             )
             db.connection.commit()
         except LinkConflictError as e:
-            await interaction.response.send_message(e.user_message(), ephemeral=True)
+            await interaction.followup.send(e.user_message(), ephemeral=True)
             return
         finally:
             db.close()
-        await self.user.edit(nick=f"{self.rank} {canonical_ign}")
         message = f'{self.added}\n\n{self.removed}'
+        try:
+            await self.user.edit(nick=f"{self.rank} {canonical_ign}")
+        except (discord.Forbidden, discord.HTTPException):
+            message += "\n\n:warning: Could not update the nickname (missing permissions) — set it manually."
         if not uuid:
             message += f"\n\n:warning: Could not resolve a Minecraft account for `{ign}` — linked without a uuid; re-link once the name is confirmed."
-        await interaction.response.send_message(message, ephemeral=True)
+        await interaction.followup.send(message, ephemeral=True)
 
 
 class NewMember(Modal):

--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -665,7 +665,18 @@ class UpdateMemberData(commands.Cog):
         self.previous_members = curr_map
         self._save_to_cache("memberList", curr_map)
 
-        # 3b: Sweep for unlinked members who are already in the guild
+        # 3b: Sync renames. The guild API name is authoritative; discord_links.ign
+        # is only ever written at link time and otherwise goes stale forever,
+        # which breaks every name-based lookup downstream (graid credit,
+        # recruiter matching, website uuid resolution).
+        try:
+            renames = await asyncio.to_thread(self._sync_member_igns, curr_map)
+            for old_ign, new_ign in renames:
+                log(INFO, f"Rename sync: {old_ign} -> {new_ign}", context="update_member_data")
+        except Exception as e:
+            log(ERROR, f"Rename sync error: {e}", context="update_member_data")
+
+        # 3c: Sweep for unlinked members who are already in the guild
         # Safety net for race conditions where a player joined before their app was accepted
         try:
             unlinked_rows = await asyncio.to_thread(self._fetch_unlinked_with_app)
@@ -1369,6 +1380,39 @@ class UpdateMemberData(commands.Cog):
             db.cursor.execute("SELECT ign FROM discord_links WHERE uuid = %s", (uuid,))
             row = db.cursor.fetchone()
             return row[0] if row else None
+        finally:
+            db.close()
+
+    @staticmethod
+    def _sync_member_igns(curr_map):
+        """Blocking: refresh discord_links.ign for members whose guild-API name
+        changed. Updates every row carrying the uuid (unlinked history rows are
+        the same person). Returns the applied (old_ign, new_ign) pairs."""
+        db = _db_connect_with_retry()
+        try:
+            db.cursor.execute(
+                "SELECT DISTINCT uuid::text, ign FROM discord_links WHERE uuid IS NOT NULL"
+            )
+            stored = {}
+            for row_uuid, row_ign in db.cursor.fetchall():
+                stored.setdefault(row_uuid.replace('-', ''), set()).add(row_ign)
+
+            renames = []
+            for uuid, info in curr_map.items():
+                name = info.get('name')
+                if not name:
+                    continue
+                names = stored.get(uuid.replace('-', ''))
+                if names and names != {name}:
+                    db.cursor.execute(
+                        "UPDATE discord_links SET ign = %s WHERE uuid = %s",
+                        (name, uuid)
+                    )
+                    old = next(n for n in sorted(names) if n != name)
+                    renames.append((old, name))
+            if renames:
+                db.connection.commit()
+            return renames
         finally:
             db.close()
 

--- a/Tasks/update_member_data.py
+++ b/Tasks/update_member_data.py
@@ -671,8 +671,10 @@ class UpdateMemberData(commands.Cog):
         # recruiter matching, website uuid resolution).
         try:
             renames = await asyncio.to_thread(self._sync_member_igns, curr_map)
-            for old_ign, new_ign in renames:
-                log(INFO, f"Rename sync: {old_ign} -> {new_ign}", context="update_member_data")
+            for rename in renames:
+                log(INFO, f"Rename sync: {rename['old']} -> {rename['new']}", context="update_member_data")
+            if renames:
+                await self._apply_rename_nicknames(renames)
         except Exception as e:
             log(ERROR, f"Rename sync error: {e}", context="update_member_data")
 
@@ -1387,34 +1389,73 @@ class UpdateMemberData(commands.Cog):
     def _sync_member_igns(curr_map):
         """Blocking: refresh discord_links.ign for members whose guild-API name
         changed. Updates every row carrying the uuid (unlinked history rows are
-        the same person). Returns the applied (old_ign, new_ign) pairs."""
+        the same person). Returns dicts {old, new, discord_id, rank} per rename,
+        where discord_id/rank come from the linked row (None when unlinked) so
+        the caller can rebuild the Discord nickname."""
         db = _db_connect_with_retry()
         try:
             db.cursor.execute(
-                "SELECT DISTINCT uuid::text, ign FROM discord_links WHERE uuid IS NOT NULL"
+                "SELECT uuid::text, ign, discord_id, linked, rank FROM discord_links WHERE uuid IS NOT NULL"
             )
             stored = {}
-            for row_uuid, row_ign in db.cursor.fetchall():
-                stored.setdefault(row_uuid.replace('-', ''), set()).add(row_ign)
+            for row_uuid, row_ign, row_discord_id, row_linked, row_rank in db.cursor.fetchall():
+                entry = stored.setdefault(
+                    row_uuid.replace('-', ''),
+                    {'names': set(), 'discord_id': None, 'rank': None},
+                )
+                entry['names'].add(row_ign)
+                if row_linked:
+                    entry['discord_id'] = row_discord_id
+                    entry['rank'] = row_rank
 
             renames = []
             for uuid, info in curr_map.items():
                 name = info.get('name')
                 if not name:
                     continue
-                names = stored.get(uuid.replace('-', ''))
-                if names and names != {name}:
+                entry = stored.get(uuid.replace('-', ''))
+                if entry and entry['names'] != {name}:
                     db.cursor.execute(
                         "UPDATE discord_links SET ign = %s WHERE uuid = %s",
                         (name, uuid)
                     )
-                    old = next(n for n in sorted(names) if n != name)
-                    renames.append((old, name))
+                    old = next(n for n in sorted(entry['names']) if n != name)
+                    renames.append({
+                        'old': old,
+                        'new': name,
+                        'discord_id': entry['discord_id'],
+                        'rank': entry['rank'],
+                    })
             if renames:
                 db.connection.commit()
             return renames
         finally:
             db.close()
+
+    async def _apply_rename_nicknames(self, renames):
+        """Rebuild '{rank} {ign}' nicknames for renamed linked members, matching
+        what registration/promotion set. Discord can refuse (server owner, role
+        hierarchy) — log and continue, never break the loop."""
+        guild = self.client.get_guild(TAQ_GUILD_ID)
+        if guild is None:
+            return
+        for rename in renames:
+            discord_id = rename.get('discord_id')
+            if not discord_id:
+                continue
+            member = guild.get_member(discord_id)
+            if member is None:
+                try:
+                    member = await guild.fetch_member(discord_id)
+                except Exception:
+                    continue
+            nick = f"{rename.get('rank') or ''} {rename['new']}".strip()
+            try:
+                await member.edit(nick=nick, reason="Minecraft name change")
+            except discord.Forbidden:
+                log(WARN, f"No permission to update nickname for {rename['new']}", context="update_member_data")
+            except Exception as e:
+                log(ERROR, f"Nickname update failed for {rename['new']}: {e}", context="update_member_data")
 
 
 def setup(client):

--- a/tests/test_ign_rename_sync.py
+++ b/tests/test_ign_rename_sync.py
@@ -1,0 +1,110 @@
+"""
+Test suite for the discord_links ign rename sync
+(Tasks/update_member_data.py UpdateMemberData._sync_member_igns).
+
+The guild loop holds the authoritative {uuid: name} map from the Wynncraft API;
+this sync writes name changes back to discord_links, which is otherwise only
+written at link time and goes stale forever.
+
+1. A changed name updates the row and reports (old, new)
+2. Matching names touch nothing (no UPDATE, no commit)
+3. uuid dash-format differences between API and DB still match
+4. A uuid with mixed rows (one stale, one current) still converges
+5. Members with no discord_links row are ignored
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from Tasks import update_member_data as umd
+
+
+class FakeCursor:
+    def __init__(self, stored_rows):
+        self.stored_rows = stored_rows
+        self.updates = []
+
+    def execute(self, sql, params=None):
+        self._is_select = sql.strip().upper().startswith("SELECT")
+        if not self._is_select:
+            self.updates.append(params)
+
+    def fetchall(self):
+        return self.stored_rows
+
+
+class FakeDB:
+    def __init__(self, stored_rows):
+        self.cursor = FakeCursor(stored_rows)
+        self.connection = self
+        self.committed = False
+        self.closed = False
+
+    def commit(self):
+        self.committed = True
+
+    def close(self):
+        self.closed = True
+
+
+def run_sync(monkeypatch, stored_rows, curr_map):
+    db = FakeDB(stored_rows)
+    monkeypatch.setattr(umd, "_db_connect_with_retry", lambda: db)
+    renames = umd.UpdateMemberData._sync_member_igns(curr_map)
+    return db, renames
+
+
+def test_rename_updates_row(monkeypatch):
+    db, renames = run_sync(
+        monkeypatch,
+        [("110c11c8-d8b7-478d-8adf-b0f606d5f939", "JohnMadDog")],
+        {"110c11c8-d8b7-478d-8adf-b0f606d5f939": {"name": "Sedacto", "rank": "Angler"}},
+    )
+    assert renames == [("JohnMadDog", "Sedacto")]
+    assert db.cursor.updates == [("Sedacto", "110c11c8-d8b7-478d-8adf-b0f606d5f939")]
+    assert db.committed and db.closed
+
+
+def test_matching_name_untouched(monkeypatch):
+    db, renames = run_sync(
+        monkeypatch,
+        [("110c11c8-d8b7-478d-8adf-b0f606d5f939", "Sedacto")],
+        {"110c11c8-d8b7-478d-8adf-b0f606d5f939": {"name": "Sedacto", "rank": "Angler"}},
+    )
+    assert renames == []
+    assert db.cursor.updates == []
+    assert not db.committed
+
+
+def test_dashless_api_uuid_matches(monkeypatch):
+    db, renames = run_sync(
+        monkeypatch,
+        [("110c11c8-d8b7-478d-8adf-b0f606d5f939", "OldName")],
+        {"110c11c8d8b7478d8adfb0f606d5f939": {"name": "NewName", "rank": None}},
+    )
+    assert renames == [("OldName", "NewName")]
+
+
+def test_mixed_rows_converge(monkeypatch):
+    db, renames = run_sync(
+        monkeypatch,
+        [
+            ("110c11c8-d8b7-478d-8adf-b0f606d5f939", "OldName"),
+            ("110c11c8-d8b7-478d-8adf-b0f606d5f939", "NewName"),
+        ],
+        {"110c11c8-d8b7-478d-8adf-b0f606d5f939": {"name": "NewName", "rank": None}},
+    )
+    assert renames == [("OldName", "NewName")]
+    assert db.cursor.updates == [("NewName", "110c11c8-d8b7-478d-8adf-b0f606d5f939")]
+
+
+def test_unknown_member_ignored(monkeypatch):
+    db, renames = run_sync(
+        monkeypatch,
+        [("110c11c8-d8b7-478d-8adf-b0f606d5f939", "Sedacto")],
+        {"9aeb062a-f769-49bc-8046-4d9c8cc86e5a": {"name": "guywhyII", "rank": None}},
+    )
+    assert renames == []
+    assert db.cursor.updates == []

--- a/tests/test_ign_rename_sync.py
+++ b/tests/test_ign_rename_sync.py
@@ -1,24 +1,35 @@
 """
 Test suite for the discord_links ign rename sync
-(Tasks/update_member_data.py UpdateMemberData._sync_member_igns).
+(Tasks/update_member_data.py UpdateMemberData._sync_member_igns and
+_apply_rename_nicknames).
 
 The guild loop holds the authoritative {uuid: name} map from the Wynncraft API;
-this sync writes name changes back to discord_links, which is otherwise only
-written at link time and goes stale forever.
+the sync writes name changes back to discord_links (otherwise only written at
+link time — stale forever) and rebuilds the '{rank} {ign}' Discord nickname of
+the linked member.
 
-1. A changed name updates the row and reports (old, new)
+1. A changed name updates the row and reports {old, new, discord_id, rank}
 2. Matching names touch nothing (no UPDATE, no commit)
 3. uuid dash-format differences between API and DB still match
-4. A uuid with mixed rows (one stale, one current) still converges
+4. A uuid with mixed rows (one stale, one current) still converges,
+   carrying the linked row's discord_id/rank
 5. Members with no discord_links row are ignored
+6. Nicknames: linked member gets '{rank} {new name}'; Forbidden is swallowed;
+   renames without a linked discord_id are skipped
 """
 
+import asyncio
 import os
 import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from Tasks import update_member_data as umd
+
+UUID = "110c11c8-d8b7-478d-8adf-b0f606d5f939"
 
 
 class FakeCursor:
@@ -27,8 +38,7 @@ class FakeCursor:
         self.updates = []
 
     def execute(self, sql, params=None):
-        self._is_select = sql.strip().upper().startswith("SELECT")
-        if not self._is_select:
+        if not sql.strip().upper().startswith("SELECT"):
             self.updates.append(params)
 
     def fetchall(self):
@@ -59,19 +69,19 @@ def run_sync(monkeypatch, stored_rows, curr_map):
 def test_rename_updates_row(monkeypatch):
     db, renames = run_sync(
         monkeypatch,
-        [("110c11c8-d8b7-478d-8adf-b0f606d5f939", "JohnMadDog")],
-        {"110c11c8-d8b7-478d-8adf-b0f606d5f939": {"name": "Sedacto", "rank": "Angler"}},
+        [(UUID, "JohnMadDog", 609, True, "Angler")],
+        {UUID: {"name": "Sedacto", "rank": "captain"}},
     )
-    assert renames == [("JohnMadDog", "Sedacto")]
-    assert db.cursor.updates == [("Sedacto", "110c11c8-d8b7-478d-8adf-b0f606d5f939")]
+    assert renames == [{"old": "JohnMadDog", "new": "Sedacto", "discord_id": 609, "rank": "Angler"}]
+    assert db.cursor.updates == [("Sedacto", UUID)]
     assert db.committed and db.closed
 
 
 def test_matching_name_untouched(monkeypatch):
     db, renames = run_sync(
         monkeypatch,
-        [("110c11c8-d8b7-478d-8adf-b0f606d5f939", "Sedacto")],
-        {"110c11c8-d8b7-478d-8adf-b0f606d5f939": {"name": "Sedacto", "rank": "Angler"}},
+        [(UUID, "Sedacto", 609, True, "Angler")],
+        {UUID: {"name": "Sedacto", "rank": "captain"}},
     )
     assert renames == []
     assert db.cursor.updates == []
@@ -81,30 +91,70 @@ def test_matching_name_untouched(monkeypatch):
 def test_dashless_api_uuid_matches(monkeypatch):
     db, renames = run_sync(
         monkeypatch,
-        [("110c11c8-d8b7-478d-8adf-b0f606d5f939", "OldName")],
-        {"110c11c8d8b7478d8adfb0f606d5f939": {"name": "NewName", "rank": None}},
+        [(UUID, "OldName", 609, True, "Angler")],
+        {UUID.replace("-", ""): {"name": "NewName", "rank": None}},
     )
-    assert renames == [("OldName", "NewName")]
+    assert renames[0]["old"] == "OldName"
+    assert renames[0]["new"] == "NewName"
 
 
-def test_mixed_rows_converge(monkeypatch):
+def test_mixed_rows_converge_with_linked_identity(monkeypatch):
     db, renames = run_sync(
         monkeypatch,
         [
-            ("110c11c8-d8b7-478d-8adf-b0f606d5f939", "OldName"),
-            ("110c11c8-d8b7-478d-8adf-b0f606d5f939", "NewName"),
+            (UUID, "OldName", 111, False, "Starfish"),
+            (UUID, "NewName", 609, True, "Angler"),
         ],
-        {"110c11c8-d8b7-478d-8adf-b0f606d5f939": {"name": "NewName", "rank": None}},
+        {UUID: {"name": "NewName", "rank": None}},
     )
-    assert renames == [("OldName", "NewName")]
-    assert db.cursor.updates == [("NewName", "110c11c8-d8b7-478d-8adf-b0f606d5f939")]
+    assert renames == [{"old": "OldName", "new": "NewName", "discord_id": 609, "rank": "Angler"}]
+    assert db.cursor.updates == [("NewName", UUID)]
 
 
 def test_unknown_member_ignored(monkeypatch):
     db, renames = run_sync(
         monkeypatch,
-        [("110c11c8-d8b7-478d-8adf-b0f606d5f939", "Sedacto")],
+        [(UUID, "Sedacto", 609, True, "Angler")],
         {"9aeb062a-f769-49bc-8046-4d9c8cc86e5a": {"name": "guywhyII", "rank": None}},
     )
     assert renames == []
     assert db.cursor.updates == []
+
+
+def _cog_with_guild(member):
+    cog = umd.UpdateMemberData.__new__(umd.UpdateMemberData)
+    guild = MagicMock()
+    guild.get_member.return_value = member
+    cog.client = MagicMock()
+    cog.client.get_guild.return_value = guild
+    return cog
+
+
+def test_nickname_rebuilt_for_linked_member():
+    member = MagicMock()
+    member.edit = AsyncMock()
+    cog = _cog_with_guild(member)
+    asyncio.run(cog._apply_rename_nicknames(
+        [{"old": "JohnMadDog", "new": "Sedacto", "discord_id": 609, "rank": "Angler"}]
+    ))
+    member.edit.assert_awaited_once_with(nick="Angler Sedacto", reason="Minecraft name change")
+
+
+def test_nickname_forbidden_swallowed():
+    member = MagicMock()
+    member.edit = AsyncMock(side_effect=discord.Forbidden(MagicMock(status=403), "no"))
+    cog = _cog_with_guild(member)
+    asyncio.run(cog._apply_rename_nicknames(
+        [{"old": "A", "new": "B", "discord_id": 1, "rank": "Angler"}]
+    ))
+    member.edit.assert_awaited_once()
+
+
+def test_nickname_skipped_without_discord_id():
+    member = MagicMock()
+    member.edit = AsyncMock()
+    cog = _cog_with_guild(member)
+    asyncio.run(cog._apply_rename_nicknames(
+        [{"old": "A", "new": "B", "discord_id": None, "rank": None}]
+    ))
+    member.edit.assert_not_awaited()


### PR DESCRIPTION
First of a 3-PR stack (→ snipe uuid schema → snipe uuid reads). Merge this one first.

## Problem

A player's identity is their Minecraft uuid; the ign is a display value that changes on rename. `discord_links.ign` was only ever written at link time — nothing refreshed it — so it went stale forever (found in prod: a member's row two renames old). Every name-based lookup downstream then silently missed the player, worst of all `/graidlog`, which validated participants against the live guild name but resolved uuids against the stale stored name: a renamed player got NULL uuid → no event points, no LE payout, no shell credit, silently.

## Changes

- **Rename sync**: the 3-minute guild loop already fetches the authoritative `{uuid: name}` map and threw the name away. New step 3b writes changed names back to `discord_links` (all rows carrying the uuid) and logs each rename. Verified end-to-end against the live API and dev DB — it corrected the known stale row and caught three more nobody had noticed (including a full rename, Aron10 → Aron14159).
- **Discord nicknames**: each detected rename also rebuilds the linked member's `{rank} {ign}` nickname (the same shape registration and promotions set). Permission refusals (server owner, role hierarchy) are logged and skipped so the loop never breaks. On first deploy this fires once for the 5 known-stale prod names.
- **`/graidlog`**: participant uuids come from the same live guild data the names are validated against, `discord_links` as fallback only; unresolved participants are called out in the confirmation instead of silently losing credit.
- **`LinkAccount` modal**: resolves the uuid via Mojang/Wynncraft before inserting (was writing name-only rows invisible to every uuid-keyed join), guarded with the same `LinkConflictError` as other link paths.

## Testing

- New `tests/test_ign_rename_sync.py` (rename, no-op, dash-format mismatch, mixed stale/current rows, unknown member)
- Full suite: 173 passed (rename, nickname rebuild, Forbidden handling, unlinked skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
