### PR TITLE
Add uuid identity to snipes, kick list removal, and annihilation signups

### DIFF
--- a/Commands/kick_list.py
+++ b/Commands/kick_list.py
@@ -68,7 +68,11 @@ class KickList(commands.Cog):
     ):
         await ctx.interaction.response.defer(ephemeral=True)
 
-        removed = await asyncio.to_thread(_remove_from_kick_list_sync, ign)
+        # Resolve the current name to a uuid so a renamed player can still be
+        # removed — the stored ign is a snapshot from when they were added.
+        result = await asyncio.to_thread(getPlayerUUID, ign)
+        uuid = result[1] if result else None
+        removed = await asyncio.to_thread(_remove_from_kick_list_sync, ign, uuid)
         if not removed:
             await ctx.followup.send(
                 f"**{discord.utils.escape_markdown(ign)}** was not found on the kick list.", ephemeral=True

--- a/Helpers/annihilation_parties.py
+++ b/Helpers/annihilation_parties.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 import discord
 
 from Helpers.database import DB
+from Helpers.functions import getPlayerUUID
 
 PARTY_COUNT = 5
 PARTY_SIZE = 10
@@ -370,9 +371,16 @@ def _assert_unique_identity(
     discord_id: int,
     ign: str,
     *,
+    uuid: str | None = None,
     exclude_member_id: int | None = None,
 ) -> None:
+    # Identity is the Minecraft uuid when known — the name comparison alone
+    # lets a renamed player hold two slots (or be blocked by someone's old name).
+    identity_sql = "(discord_id = %s OR LOWER(ign) = LOWER(%s))"
     params: list = [event_id, discord_id, ign]
+    if uuid:
+        identity_sql = "(discord_id = %s OR LOWER(ign) = LOWER(%s) OR uuid = %s)"
+        params.append(uuid)
     exclude_sql = ""
     if exclude_member_id is not None:
         exclude_sql = "AND id <> %s"
@@ -382,7 +390,7 @@ def _assert_unique_identity(
         SELECT discord_id, ign
         FROM annihilation_party_members
         WHERE event_id = %s
-          AND (discord_id = %s OR LOWER(ign) = LOWER(%s))
+          AND {identity_sql}
           {exclude_sql}
         LIMIT 1
         """,
@@ -427,12 +435,18 @@ def add_member(
     ign, build, party_number, combat_role, notes = _validate_entry_values(
         ign, build, party_number, combat_role, notes
     )
+    # Resolve the typed name's Minecraft uuid before taking the event lock —
+    # no HTTP while holding the transaction. The discord link is preferred
+    # inside the transaction; Mojang covers alts and unlinked names, so the
+    # row is never silently written without an identity.
+    player_data = getPlayerUUID(ign)
+    fallback_uuid = player_data[1] if player_data else None
     db = _db()
     try:
         _lock_open_event(db, event_id)
-        _assert_unique_identity(db, event_id, discord_id, ign)
+        uuid = _linked_uuid_for_ign(db, discord_id, ign) or fallback_uuid
+        _assert_unique_identity(db, event_id, discord_id, ign, uuid=uuid)
         slot_number = _available_slot(db, event_id, party_number)
-        uuid = _linked_uuid_for_ign(db, discord_id, ign)
         db.cursor.execute(
             """
             INSERT INTO annihilation_party_members (
@@ -507,6 +521,7 @@ def update_member(
                 event_id,
                 owner_discord_id,
                 ign,
+                uuid=uuid,
                 exclude_member_id=member_id,
             )
         else:

--- a/Helpers/annihilation_parties.py
+++ b/Helpers/annihilation_parties.py
@@ -403,7 +403,9 @@ def _assert_unique_identity(
         raise AnnihilationPartyError(
             "You already have an entry. Use **Modify entry** instead"
         )
-    raise AnnihilationPartyError(f"`{ign}` is already registered for this event.")
+    # A uuid match can surface a row under a different (older) name — report
+    # the name actually on the board, not the one that was typed.
+    raise AnnihilationPartyError(f"`{row[1]}` is already registered for this event.")
 
 
 def _available_slot(db: DB, event_id: int, party_number: int) -> int:

--- a/Tasks/kick_list_tracker.py
+++ b/Tasks/kick_list_tracker.py
@@ -69,14 +69,22 @@ def _add_to_kick_list_sync(uuid: str, ign: str, tier: int, added_by: str):
         db.close()
 
 
-def _remove_from_kick_list_sync(ign: str) -> bool:
+def _remove_from_kick_list_sync(ign: str, uuid: str | None = None) -> bool:
+    """Remove by uuid when known (the table's PK — survives renames), falling
+    back to the stored name snapshot for entries added before uuid resolution
+    or when the lookup failed."""
     db = DB()
     db.connect()
     try:
-        db.cursor.execute(
-            "DELETE FROM kick_list WHERE LOWER(ign) = LOWER(%s)", (ign,)
-        )
-        removed = db.cursor.rowcount > 0
+        removed = False
+        if uuid:
+            db.cursor.execute("DELETE FROM kick_list WHERE uuid = %s", (uuid,))
+            removed = db.cursor.rowcount > 0
+        if not removed:
+            db.cursor.execute(
+                "DELETE FROM kick_list WHERE LOWER(ign) = LOWER(%s)", (ign,)
+            )
+            removed = db.cursor.rowcount > 0
         db.connection.commit()
         return removed
     finally:

--- a/schema.sql
+++ b/schema.sql
@@ -354,6 +354,21 @@ BEGIN
   END IF;
 END $$;
 
+-- Re-runnable on every replay: resolve remaining NULL-uuid snipe rows from
+-- unambiguous (uuid, name) pairs in the raid logs — a name-history source
+-- that covers snapshots older than the player's current name, which the
+-- discord_links backfill above can never match.
+UPDATE snipe_participants sp
+SET uuid = h.uuid
+FROM (
+  SELECT LOWER(ign) AS name_key, MIN(uuid::text)::uuid AS uuid
+  FROM graid_log_participants
+  WHERE uuid IS NOT NULL AND ign IS NOT NULL
+  GROUP BY LOWER(ign)
+  HAVING COUNT(DISTINCT uuid) = 1
+) h
+WHERE sp.uuid IS NULL AND h.name_key = LOWER(sp.ign);
+
 -- Seed app_counter if missing (won't overwrite existing value)
 INSERT INTO bot_settings (key, value) VALUES ('app_counter', '3725') ON CONFLICT DO NOTHING;
 

--- a/schema.sql
+++ b/schema.sql
@@ -328,6 +328,21 @@ BEGIN
     ALTER TABLE applications ADD COLUMN app_number INT;
   END IF;
 
+  -- snipe_participants: uuid column for stable player identity (ign is a
+  -- display snapshot that goes stale on rename). Backfill from linked
+  -- discord_links rows by current name; unmatched rows stay NULL and keep
+  -- ign-keyed fallback identity.
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'snipe_participants' AND column_name = 'uuid') THEN
+    ALTER TABLE snipe_participants ADD COLUMN uuid UUID;
+    UPDATE snipe_participants sp
+    SET uuid = dl.uuid
+    FROM discord_links dl
+    WHERE sp.uuid IS NULL
+      AND dl.linked = TRUE
+      AND dl.uuid IS NOT NULL
+      AND LOWER(dl.ign) = LOWER(sp.ign);
+  END IF;
+
   -- graid_log_queue: the old mode column ('group'/'individual') is replaced by
   -- the announce flag — party size no longer changes how a raid is processed.
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'graid_log_queue' AND column_name = 'announce') THEN
@@ -467,6 +482,11 @@ CREATE TABLE IF NOT EXISTS annihilation_party_members (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_annihilation_party_members_ign
   ON annihilation_party_members(event_id, LOWER(ign));
+
+-- The name index alone cannot stop a renamed player from holding two slots;
+-- the uuid is the stable identity when resolvable.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_annihilation_party_members_uuid
+  ON annihilation_party_members(event_id, uuid) WHERE uuid IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_annihilation_party_members_party
   ON annihilation_party_members(event_id, party_number, party_joined_at, id);
@@ -669,13 +689,16 @@ END $$;
 
 CREATE TABLE IF NOT EXISTS snipe_participants (
   snipe_id    INT         NOT NULL REFERENCES snipe_logs(id) ON DELETE CASCADE,
-  ign         VARCHAR(64) NOT NULL,
+  ign         VARCHAR(64) NOT NULL,   -- display snapshot at log time
+  uuid        UUID,                   -- player identity; ign-keyed fallback when NULL
   role        VARCHAR(10) NOT NULL,
   PRIMARY KEY (snipe_id, ign)
 );
 
 CREATE INDEX IF NOT EXISTS idx_snipe_participants_ign
   ON snipe_participants(ign);
+CREATE INDEX IF NOT EXISTS idx_snipe_participants_uuid
+  ON snipe_participants(uuid);
 
 CREATE INDEX IF NOT EXISTS idx_snipe_logs_sniped_at
   ON snipe_logs(sniped_at DESC);

--- a/schema.sql
+++ b/schema.sql
@@ -324,15 +324,21 @@ BEGIN
     ALTER TABLE new_app ADD COLUMN app_message_id BIGINT;
   END IF;
   -- applications: app_number column for persistent counter-based naming
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'applications' AND column_name = 'app_number') THEN
+  -- (table-existence guard: on a fresh database the table is created later
+  -- in this file, with the column already present)
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'applications')
+     AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'applications' AND column_name = 'app_number') THEN
     ALTER TABLE applications ADD COLUMN app_number INT;
   END IF;
 
   -- snipe_participants: uuid column for stable player identity (ign is a
   -- display snapshot that goes stale on rename). Backfill from linked
   -- discord_links rows by current name; unmatched rows stay NULL and keep
-  -- ign-keyed fallback identity.
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'snipe_participants' AND column_name = 'uuid') THEN
+  -- ign-keyed fallback identity. The table-existence guard matters: this DO
+  -- block runs before the CREATE TABLE further down, so on a fresh database
+  -- there is nothing to migrate (the CREATE already includes the column).
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'snipe_participants')
+     AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'snipe_participants' AND column_name = 'uuid') THEN
     ALTER TABLE snipe_participants ADD COLUMN uuid UUID;
     UPDATE snipe_participants sp
     SET uuid = dl.uuid
@@ -357,20 +363,24 @@ END $$;
 -- Re-runnable on every replay: resolve remaining NULL-uuid snipe rows from
 -- unambiguous (uuid, name) pairs in the raid logs — a name-history source
 -- that covers snapshots older than the player's current name, which the
--- discord_links backfill above can never match.
-UPDATE snipe_participants sp
-SET uuid = h.uuid
-FROM (
-  SELECT LOWER(ign) AS name_key, MIN(uuid::text)::uuid AS uuid
-  FROM graid_log_participants
-  WHERE uuid IS NOT NULL AND ign IS NOT NULL
-  GROUP BY LOWER(ign)
-  HAVING COUNT(DISTINCT uuid) = 1
-) h
-WHERE sp.uuid IS NULL AND h.name_key = LOWER(sp.ign);
+-- discord_links backfill above can never match. Guarded because this runs
+-- before the snipe tables are created on a fresh database.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'snipe_participants') THEN
+    UPDATE snipe_participants sp
+    SET uuid = h.uuid
+    FROM (
+      SELECT LOWER(ign) AS name_key, MIN(uuid::text)::uuid AS uuid
+      FROM graid_log_participants
+      WHERE uuid IS NOT NULL AND ign IS NOT NULL
+      GROUP BY LOWER(ign)
+      HAVING COUNT(DISTINCT uuid) = 1
+    ) h
+    WHERE sp.uuid IS NULL AND h.name_key = LOWER(sp.ign);
+  END IF;
+END $$;
 
--- Seed app_counter if missing (won't overwrite existing value)
-INSERT INTO bot_settings (key, value) VALUES ('app_counter', '3725') ON CONFLICT DO NOTHING;
 
 -- =============================================================================
 -- Guild Bank Transactions
@@ -628,6 +638,9 @@ CREATE TABLE IF NOT EXISTS bot_settings (
   key   TEXT PRIMARY KEY,
   value TEXT NOT NULL
 );
+
+-- Seed app_counter if missing (won't overwrite existing value)
+INSERT INTO bot_settings (key, value) VALUES ('app_counter', '3725') ON CONFLICT DO NOTHING;
 
 -- =============================================================================
 -- Promotion Queue

--- a/tests/test_annihilation_parties.py
+++ b/tests/test_annihilation_parties.py
@@ -247,3 +247,103 @@ def test_pycord_28_modal_contains_native_selects():
     assert modal.get_item("scrolls").options
     assert any(option.default for option in modal.get_item("scrolls").options)
     assert modal.get_item("ign") is None
+
+
+# ── uuid-based signup dedup (_assert_unique_identity) ────────────────────────
+
+class _FakeIdentityCursor:
+    """Replays one fetchone result and records the executed identity query."""
+
+    def __init__(self, row):
+        self.row = row
+        self.queries = []
+
+    def execute(self, sql, params=None):
+        self.queries.append((sql, params))
+
+    def fetchone(self):
+        return self.row
+
+
+class _FakeIdentityDB:
+    def __init__(self, row):
+        self.cursor = _FakeIdentityCursor(row)
+
+
+def test_unique_identity_matches_by_uuid_and_reports_board_name():
+    from Helpers.annihilation_parties import _assert_unique_identity
+
+    db = _FakeIdentityDB((999, "OldName"))
+    with pytest.raises(AnnihilationPartyError) as excinfo:
+        _assert_unique_identity(
+            db, 1, 42, "NewName", uuid="110c11c8-d8b7-478d-8adf-b0f606d5f939"
+        )
+    # The message names the row already on the board, not the typed name.
+    assert "OldName" in str(excinfo.value)
+    sql, params = db.cursor.queries[0]
+    assert "uuid = %s" in sql
+    assert params == (1, 42, "NewName", "110c11c8-d8b7-478d-8adf-b0f606d5f939")
+
+
+def test_unique_identity_without_uuid_keeps_name_only_match():
+    from Helpers.annihilation_parties import _assert_unique_identity
+
+    db = _FakeIdentityDB(None)
+    _assert_unique_identity(db, 1, 42, "SomeName")
+    sql, params = db.cursor.queries[0]
+    assert "uuid" not in sql
+    assert params == (1, 42, "SomeName")
+
+
+def test_unique_identity_same_discord_id_reports_own_entry():
+    from Helpers.annihilation_parties import _assert_unique_identity
+
+    db = _FakeIdentityDB((42, "SomeName"))
+    with pytest.raises(AnnihilationPartyError) as excinfo:
+        _assert_unique_identity(db, 1, 42, "SomeName", uuid="abc")
+    assert "already have an entry" in str(excinfo.value)
+
+
+def test_add_member_prefers_link_but_falls_back_to_mojang(monkeypatch):
+    import Helpers.annihilation_parties as ap
+
+    # No linked account row → the pre-lock Mojang resolution must supply the uuid.
+    captured = {}
+
+    class _Cursor:
+        def execute(self, sql, params=None):
+            self.sql = sql
+            self.params = params
+            if "INSERT INTO annihilation_party_members" in sql:
+                captured["insert_params"] = params
+
+        def fetchone(self):
+            if "INSERT INTO annihilation_party_members" in getattr(self, "sql", ""):
+                return (77,)
+            return None
+
+        def fetchall(self):
+            return []
+
+    class _DB:
+        cursor = _Cursor()
+
+        def close(self):
+            pass
+
+        class connection:
+            @staticmethod
+            def commit():
+                pass
+
+    monkeypatch.setattr(ap, "_db", lambda: _DB())
+    monkeypatch.setattr(ap, "_lock_open_event", lambda db, event_id: None)
+    monkeypatch.setattr(ap, "_available_slot", lambda db, event_id, party: 1)
+    monkeypatch.setattr(ap, "getPlayerUUID", lambda ign: [ign, "967a422d-60bc-4cc6-8fff-c2d067f841eb"])
+
+    member_id = ap.add_member(
+        event_id=1, discord_id=42, ign="RestlessFish080", build="Trapper",
+        party_number=1, combat_role=None, bringing_scrolls=False, notes=None,
+    )
+    assert member_id == 77
+    assert "967a422d-60bc-4cc6-8fff-c2d067f841eb" in captured["insert_params"]


### PR DESCRIPTION
Second of the 3-PR stack, on top of the rename-sync PR.

## Changes

- **`snipe_participants.uuid`** (nullable) + indexes, with an idempotent schema.sql migration that backfills from linked `discord_links` rows by name. Unmatched historical rows stay NULL and keep ign-fallback identity. The snipe write path change (inserting the uuid resolved from live guild data) rides in the next PR of the stack (#310) alongside the other snipe.py changes; until that merges, new rows keep NULL uuids, which the re-runnable history backfill and read-side fallback both tolerate. Backfill is two-stage: linked `discord_links` by current name, then a re-runnable pass matching remaining NULL rows against unambiguous `(uuid, name)` pairs from `graid_log_participants` — a name-history source that covers snapshots older than the player's current name, which also makes the backfill independent of deploy order. Dry-run against prod: 934 rows / 40 distinct names → 913 match via discord_links, 19 more via raid-log history (0 ambiguous), leaving only 2 rows for one name that no longer exists on Mojang (kept as ign-fallback identity by design). Dev DB already migrated.
- **`/kicklist remove`** resolves the typed name to a uuid (the table's PK) before deleting, stored-name fallback second — a renamed player could previously never be removed from the board.
- **Annihilation signups**: the typed name resolves via Mojang before the event lock (no HTTP inside the transaction), dedup checks uuid as well as discord_id/name, and a partial unique index on `(event_id, uuid)` backs it up — a renamed player can no longer hold two slots.

## Testing

- Full suite: 170 passed; dev DB schema replay verified column, backfill, and index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

