### PR TITLE
[TAQ-47] fix right-edge geometry on the guild XP and shell leaderboards

### DIFF
--- a/Commands/leaderboard.py
+++ b/Commands/leaderboard.py
@@ -220,8 +220,17 @@ def create_leaderboard(order_key: str, key_icon: str, header: str, days: int = 7
     widest = 0
     book: List[Page] = []
 
+    # Row geometry. The bar is centered in the canvas; the gutter on each side is sized
+    # to fit the warning icon that overhangs the bar's right edge (16px icon + 6px gap
+    # + 8px margin). Everything inside the row is positioned relative to SIDE_PAD (left
+    # edge of the bar) or BAR_R (right edge) so the two insets stay symmetric.
+    BAR_W = 530
+    SIDE_PAD = 30
+    BAR_R = SIDE_PAD + BAR_W
+    CANVAS_W = BAR_R + SIDE_PAD
+
     for page_index in range(total_pages):
-        img = Image.new('RGBA', (560, 0), color='#00000000')
+        img = Image.new('RGBA', (CANVAS_W, 0), color='#00000000')
         draw = ImageDraw.Draw(img)
         draw.fontmode = '1'
 
@@ -237,16 +246,16 @@ def create_leaderboard(order_key: str, key_icon: str, header: str, days: int = 7
             else:
                 bg_color = bg_other
 
-            # Warning icon for partial window/late join/missing baseline
-            if player['warning']:
-                img.paste(warning_icon, (img.width - 24, row_idx * 36 + 11), warning_icon)
-
             # Slot background & dividers
-            # LEFT_PAD = 15: canvas is 560px, bg bar is 530px -- shift content right by 15 for equal padding
-            LEFT_PAD = 15
-            bg_color.add(img, 530, (LEFT_PAD, row_idx * 36 + 3), start=True)
-            img.paste(bg_color.divider, (LEFT_PAD + 55, row_idx * 36 + 3), bg_color.divider)
-            addLine(f'&f{rank_counter}.', draw, game_font, LEFT_PAD + 10, row_idx * 36 + 9)
+            bg_color.add(img, BAR_W, (SIDE_PAD, row_idx * 36 + 3), start=True)
+            img.paste(bg_color.divider, (SIDE_PAD + 55, row_idx * 36 + 3), bg_color.divider)
+            addLine(f'&f{rank_counter}.', draw, game_font, SIDE_PAD + 10, row_idx * 36 + 9)
+
+            # Warning icon for partial window/late join/missing baseline. Sits in the
+            # right gutter, just outside the bar -- drawn after the bar so it can't be
+            # painted over.
+            if player['warning']:
+                img.paste(warning_icon, (BAR_R + 6, row_idx * 36 + 11), warning_icon)
 
             # Rank stars (based on discord rank mapping)
             rank_key = (player.get('rank') or '').lower()
@@ -257,22 +266,22 @@ def create_leaderboard(order_key: str, key_icon: str, header: str, days: int = 7
                     break
             stars = rank_map.get(general_rank, '')
             for s in range(len(stars)):
-                img.paste(rank_star, (LEFT_PAD + 65 + (s * 12), row_idx * 36 + 14), rank_star)
+                img.paste(rank_star, (SIDE_PAD + 65 + (s * 12), row_idx * 36 + 14), rank_star)
 
             # Name divider
-            img.paste(bg_color.divider, (LEFT_PAD + 133, row_idx * 36 + 3), bg_color.divider)
-            addLine(f'&f{player["name"]}', draw, game_font, LEFT_PAD + 143, row_idx * 36 + 9)
+            img.paste(bg_color.divider, (SIDE_PAD + 133, row_idx * 36 + 3), bg_color.divider)
+            addLine(f'&f{player["name"]}', draw, game_font, SIDE_PAD + 143, row_idx * 36 + 9)
 
-            # Value text right aligned
+            # Value text right aligned, 10px inside the bar to mirror the rank number
             value_str = "{:,}".format(int(player['contributed']))
             _, _, w, _ = draw.textbbox((0, 0), value_str, font=game_font)
             if rank_counter == 1:
                 widest = w
-            addLine(f'&f{value_str}', draw, game_font, img.width - 40 - w, row_idx * 36 + 9)
+            addLine(f'&f{value_str}', draw, game_font, BAR_R - 10 - w, row_idx * 36 + 9)
 
             # Icon & divider near value
-            img.paste(icon, (img.width - 65 - widest, row_idx * 36 + 11), icon)
-            img.paste(bg_color.divider, (img.width - 75 - widest, row_idx * 36 + 3), bg_color.divider)
+            img.paste(icon, (BAR_R - 35 - widest, row_idx * 36 + 11), icon)
+            img.paste(bg_color.divider, (BAR_R - 45 - widest, row_idx * 36 + 3), bg_color.divider)
 
             rank_counter += 1
 

--- a/Commands/shell.py
+++ b/Commands/shell.py
@@ -94,8 +94,18 @@ class Shell(commands.Cog):
             page_num = int(math.ceil(len(shelldata) / 10))
             i = 1
 
+            # Row geometry, mirroring Commands/leaderboard.py: the bar is centered in the
+            # canvas and every element is placed relative to SIDE_PAD (bar's left edge) or
+            # BAR_R (right edge) so the two insets stay symmetric. The gutter is narrower
+            # than the leaderboard's 30px because nothing overhangs the bar here -- widen
+            # it if an icon is ever added outside the bar.
+            BAR_W = 380
+            SIDE_PAD = 15
+            BAR_R = SIDE_PAD + BAR_W
+            CANVAS_W = BAR_R + SIDE_PAD
+
             for page in range(page_num):
-                img = Image.new('RGBA', (410, 0), color='#00000000')
+                img = Image.new('RGBA', (CANVAS_W, 0), color='#00000000')
                 d = ImageDraw.Draw(img)
                 d.fontmode = '1'
                 page_playerdata = shelldata[(10 * page):(10 * page + 10)]
@@ -103,17 +113,19 @@ class Shell(commands.Cog):
                 for p, player in enumerate(page_playerdata):
                     img, d = expand_image(img, border=(0, 0, 0, 36), fill='#00000000')
                     bg_color = {1: bg1, 2: bg2, 3: bg3}.get(i, bg)
-                    bg_color.add(img, 380, (0, p * 36 + 3))
-                    img.paste(bg_color.divider, (55, p * 36 + 3), bg_color.divider)
+                    # start=True draws the mirrored left cap; without it the bar has a raw
+                    # cut edge, which only looked right while it was flush against x=0.
+                    bg_color.add(img, BAR_W, (SIDE_PAD, p * 36 + 3), start=True)
+                    img.paste(bg_color.divider, (SIDE_PAD + 55, p * 36 + 3), bg_color.divider)
                     pos = f'{i}.'
-                    addLine(f'&f{pos}', d, gameFont, 10, p * 36 + 9)
-                    addLine(f"&f{player['name']}", d, gameFont, 65, p * 36 + 9)
+                    addLine(f'&f{pos}', d, gameFont, SIDE_PAD + 10, p * 36 + 9)
+                    addLine(f"&f{player['name']}", d, gameFont, SIDE_PAD + 65, p * 36 + 9)
                     _, _, w, h = d.textbbox((0, 0), f"{player['shells']:,}", font=gameFont)
                     if i == 1:
                         widest = w
-                    addLine(f"&f{player['shells']:,}", d, gameFont, img.width - 40 - w, p * 36 + 9)
-                    img.paste(shells_img, (img.width - 65 - widest, p * 36 + 11), shells_img)
-                    img.paste(bg_color.divider, (img.width - 75 - widest, p * 36 + 3), bg_color.divider)
+                    addLine(f"&f{player['shells']:,}", d, gameFont, BAR_R - 10 - w, p * 36 + 9)
+                    img.paste(shells_img, (BAR_R - 35 - widest, p * 36 + 11), shells_img)
+                    img.paste(bg_color.divider, (BAR_R - 45 - widest, p * 36 + 3), bg_color.divider)
                     i += 1
 
                 img, d = expand_image(img, border=(0, 120, 0, 10), fill='#00000000')


### PR DESCRIPTION
https://www.the-aquarium.com/exec/requests/47

The centering pass moved each table's background bar but left the elements that were positioned from the canvas edge where they were.

## Guild XP leaderboard

**The partial-period clock icon.** This is the timer shown for members who haven't been in the guild for the full period (late join / missing baseline). It was pasted at a fixed `img.width - 24` = 536–552, but centering moved the bar to 15–545, so 9 of its 16px landed on top of the bar. It was also pasted *before* `bg_color.add(...)` drew the bar, so the bar painted straight over it. Only a 7px sliver survived in the gutter, which reads as edge shading rather than an icon.

**Everything else on the right.** The value text, key icon and divider still used `img.width - 40/65/75`. Those constants encoded a 10px inset from the bar's right edge back when the bar ended at 530; against the moved bar the inset became 25px, versus 10px for the rank number on the left. Not clipped, just asymmetric, which is why it read as fine.

**Fix.** Canvas widened 560 → 590 so a 16px icon fits outside the bar (a 15px gutter can't hold one); this restores the 6px clearance and 8px margin the layout had before centering. Geometry hoisted to `BAR_W`/`SIDE_PAD`/`BAR_R`/`CANVAS_W` above the page loop — `LEFT_PAD` was being redeclared every row, and declared *after* the line that needed it. Every element now positions off the bar's edges, and the icon is pasted after the bar so draw order can't bury it again. The header, badge and background all paste at `img.width // 2`, so they re-center on their own, and `leaderboard_bg.png` is 1333px wide — the extra 30px just reveals more of it.

## Shell leaderboard

Centered the same way, per follow-up. The bar moves from `0–380` to `15–395` inside the unchanged 410px canvas, so it lines up with the title and badge instead of sitting 15px to their left. Canvas size and bar width are unchanged — only its x moved, so no row content was reflowed.

Right column moved from `img.width - 40/65/75` to `BAR_R - 10/35/45`. That's numerically identical today, but it's what stops the column drifting if the padding is touched again — the exact failure above.

`add()` now passes `start=True`. shell.py was calling it without, which skips the mirrored left cap and leaves the bar a square cut. That looked fine flush against x=0; centered, it would have been a raw edge floating mid-canvas.

Gutter here is 15px, not the leaderboard's 30px, because nothing overhangs the bar on this table — a comment at the constants records why, so it's clear what to widen if a clock icon is ever added.

## Verification

Both files rendered before and after from the real assets with fake rows (some flagged partial-period, some not) to confirm the icon appears, the insets match, and the left cap is correct. `py -m py_compile` passes on both.

Rendering geometry only — no data, sorting or command logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)